### PR TITLE
Add Dockerfile-runtime

### DIFF
--- a/Dockerfile-runtime
+++ b/Dockerfile-runtime
@@ -1,15 +1,6 @@
-# Copy this file and Run from one level higher than the git pull directory
-# To build: docker build -t opsh2o4gpu/h2o4gpu-runtime -f Dockerfile-runtime .
-# To run: nvidia-docker run -it --rm -p 12345:12345 opsh2o4gpu/h2o4gpu-runtime
-
-# run app:
-# nvidia-docker run --rm -v /var/tmp:/data -v /var/tmp:/log -p 12345:12345 -d opsh2o4gpu/h2o4gpu-runtime
-
-# run tests:
-# nvidia-docker run --rm -v $PWD/tests:/tests opsh2o4gpu/h2o4gpu-runtime /tests pytest --verbose -n auto
-
-# go inside:
-# nvidia-docker run --rm -it -v $PWD/tests:/tests --entrypoint bash opsh2o4gpu/h2o4gpu-runtime
+#How to run:
+#docker build -t opsh2oai/h2o4gpu -f Dockerfile-runtime .
+#nvidia-docker run -p 8888:8888 -v /some/local/log:/log opsh2oai/h2o4gpu &
 
 FROM nvidia/cuda:8.0-cudnn5-runtime-ubuntu16.04
 MAINTAINER H2o.ai <ops@h2o.ai>

--- a/Dockerfile-runtime
+++ b/Dockerfile-runtime
@@ -1,0 +1,93 @@
+# Copy this file and Run from one level higher than the git pull directory
+# To build: docker build -t opsh2o4gpu/h2o4gpu-runtime -f Dockerfile-runtime .
+# To run: nvidia-docker run -it --rm -p 12345:12345 opsh2o4gpu/h2o4gpu-runtime
+
+# run app:
+# nvidia-docker run --rm -v /var/tmp:/data -v /var/tmp:/log -p 12345:12345 -d opsh2o4gpu/h2o4gpu-runtime
+
+# run tests:
+# nvidia-docker run --rm -v $PWD/tests:/tests opsh2o4gpu/h2o4gpu-runtime /tests pytest --verbose -n auto
+
+# go inside:
+# nvidia-docker run --rm -it -v $PWD/tests:/tests --entrypoint bash opsh2o4gpu/h2o4gpu-runtime
+
+FROM nvidia/cuda:8.0-cudnn5-runtime-ubuntu16.04
+MAINTAINER H2o.ai <ops@h2o.ai>
+
+ENV DEBIAN_FRONTEND noninteractive
+ENV CUDA_HOME=/usr/local/cuda
+ENV PATH=/usr/local/cuda/bin:$PATH
+ENV LD_LIBRARY_PATH_MORE=/home/$USER/lib/:$CUDA_HOME/lib64/:$CUDA_HOME/lib/:/usr/local/cuda/lib64:/usr/local/cuda/extras/CUPTI/lib64:/usr/local/nvidia/lib:/usr/local/nvidia/lib64
+ENV LD_LIBRARY_PATH=$LD_LIBRARY_PATH:$LD_LIBRARY_PATH_MORE
+ENV CUDADIR=/usr/local/cuda/include/
+ENV OMP_NUM_THREADS=32
+ENV MKL_NUM_THREADS=32
+ENV VECLIB_MAXIMUM_THREADS=32
+
+RUN \
+  # Setup Repos
+  apt-get update -y && \
+  apt-get -y install curl apt-utils python-software-properties \
+  software-properties-common iputils-ping wget cpio net-tools build-essential \
+  git zip dirmngr && \
+  apt-get -y --no-install-recommends  install \
+      python3-dateutil \
+      python3-magic && \
+  wget http://launchpadlibrarian.net/326935544/s3cmd_2.0.0-1_all.deb && \
+  dpkg -i s3cmd_2.0.0-1_all.deb && \
+  add-apt-repository ppa:fkrull/deadsnakes  && \
+  apt-get update -yqq && \
+  curl -sL https://deb.nodesource.com/setup_7.x | bash - && \
+  # Install H2o dependencies
+  apt-get -y --no-install-recommends  install \
+    python3.6 \
+    python3.6-dev \
+    virtualenv \
+    python3-pip && \
+  update-alternatives --install /usr/bin/python python /usr/bin/python3.6 100 && \
+  python -m pip install --upgrade pip && \
+  apt-get clean && \
+  rm -rf /var/cache/apt/* && \
+  apt-get install -y libopenblas-dev
+
+RUN \
+  mkdir h2o4gpu_env && \
+  virtualenv --python=/usr/bin/python3.6 h2o4gpu_env && \
+  chmod -R o+w h2o4gpu_env && \
+  . h2o4gpu_env/bin/activate && \
+  pip install --no-cache-dir --upgrade pip && \
+  pip install --no-cache-dir --upgrade setuptools && \
+  pip install --no-cache-dir --upgrade numpy && \
+  pip install --no-cache-dir --upgrade jupyter
+
+# Add requirements
+COPY requirements_runtime.txt requirements.txt
+RUN \
+  . h2o4gpu_env/bin/activate && \
+  pip install --no-cache-dir -r requirements.txt
+
+RUN \
+  . h2o4gpu_env/bin/activate && \
+  pip install --no-cache-dir https://s3.amazonaws.com/artifacts.h2o.ai/releases/stable/ai/h2o/h2o4gpu/0.0.4/h2o4gpu-0.0.4-py36-none-any.whl
+
+# Add a canned jupyter notebook demo to the container
+RUN \
+  mkdir -p jupyter/demos
+COPY examples/py/demos/H2O4GPU_GLM.ipynb /jupyter/demos/H2O4GPU_GLM.ipynb
+RUN \
+  . h2o4gpu_env/bin/activate && \
+  cd /jupyter/demos && \
+  chmod -R o+w /jupyter
+
+# Add shell wrapper
+COPY run.sh /run.sh
+
+ARG h2o4gpu_VERSION
+ARG h2o4gpu_COMMIT
+ARG DOCKER_VERSION_TAG
+LABEL \
+h2o4gpu_commit="$h2o4gpu_COMMIT" \
+docker_version_tag="$DOCKER_VERSION_TAG"
+
+ENTRYPOINT ["./run.sh"]  
+EXPOSE 8888

--- a/Dockerfile-runtime
+++ b/Dockerfile-runtime
@@ -1,6 +1,6 @@
 #How to run:
-#docker build -t opsh2oai/h2o4gpu -f Dockerfile-runtime .
-#nvidia-docker run -p 8888:8888 -v /some/local/log:/log opsh2oai/h2o4gpu &
+#To build: docker build -t opsh2oai/h2o4gpu -f Dockerfile-runtime .
+#To run: nvidia-docker run -p 8888:8888 -v /some/local/log:/log opsh2oai/h2o4gpu &
 
 FROM nvidia/cuda:8.0-cudnn5-runtime-ubuntu16.04
 MAINTAINER H2o.ai <ops@h2o.ai>

--- a/run.sh
+++ b/run.sh
@@ -1,0 +1,24 @@
+#!/bin/bash
+
+#
+# Note:  This run script is meant to be run inside the docker container.
+#
+
+set -e
+
+source h2o4gpu_env/bin/activate
+
+if [ "x$1" != "x" ]; then
+    d=$1
+    cd $d
+    shift
+    exec "$@"
+fi
+
+logdir=/log/`date "+%Y%m%d-%H%M%S"`
+mkdir -p "$logdir"
+
+export HOME=/jupyter && \
+cd /jupyter && \
+jupyter --paths >> "$logdir"/jupyter.log && \
+exec jupyter notebook --ip='*' --no-browser --allow-root >> "$logdir"/jupyter.log 2>&1


### PR DESCRIPTION
* Add DockerFile for runtime. 
* Comes with one GLM notebook for now (we can add more).
* Commands to run are as follows:
`
docker build -t opsh2oai/h2o4gpu -f Dockerfile-runtime .
`
`
nvidia-docker run -p 8888:8888 -v /some/local/log:/log opsh2oai/h2o4gpu &
`
* `cd` into /some/local/log/2017* and `vi` jupyter log to get token to see jupyter notebook at `localhost:8888`. For example, the log will show: 
`
http://localhost:8888/?token=e24dd181833e6ffc5a9219bbf62265288f7f7a05f3d52587
`
* Point your browser to `localhost:8888`, enter token, and run GLM notebook.

