### PR TITLE
Fixes #177 Improved matrix multiplication for skinny matrices

### DIFF
--- a/src/gpu/kmeans/kmeans_impl.h
+++ b/src/gpu/kmeans/kmeans_impl.h
@@ -165,7 +165,7 @@ int kmeans(
     }
 
     // Scale the centroids on host
-    if(n_gpu > 1) {
+    if (n_gpu > 1) {
       //Average the centroids from each device
       for (int p = 0; p < k; p++) h_counts[p] = 0.0;
       for (int q = 0; q < n_gpu; q++) {
@@ -179,7 +179,7 @@ int kmeans(
       for (int p = 0; p < k; p++) {
         for (int r = 0; r < d; r++) {
           if (h_counts_tmp[p] != 0) {
-            h_centroids[p*d + r] = 0.0;
+            h_centroids[p * d + r] = 0.0;
           }
         }
       }
@@ -191,7 +191,7 @@ int kmeans(
         for (int p = 0; p < k; p++) {
           for (int r = 0; r < d; r++) {
             if (h_counts_tmp[p] != 0) {
-              h_centroids[p*d + r] += h_centroids_tmp[p*d + r];
+              h_centroids[p * d + r] += h_centroids_tmp[p * d + r];
             }
           }
         }
@@ -200,7 +200,7 @@ int kmeans(
       for (int p = 0; p < k; p++) {
         for (int r = 0; r < d; r++) {
           // If 0 counts that means we leave the original centroids
-          if(h_counts[p] == 0) {
+          if (h_counts[p] == 0) {
             h_counts[p] = 1;
           }
           h_centroids[p * d + r] /= h_counts[p];

--- a/src/gpu/kmeans/kmeans_labels.cu
+++ b/src/gpu/kmeans/kmeans_labels.cu
@@ -74,10 +74,11 @@ void streamsync(int dev_num) {
 template<typename float_t>
 __global__ void matmul(const float_t *A, const float_t *B, float_t *C,
                        const float_t alpha, const float_t beta, int n, int d, int k, int max_block_rows) {
-  extern __shared__ float_t
-  shared[];
-  float_t * s_A = shared;
-  float_t * s_B = shared + max_block_rows * d;
+  extern __shared__ __align__(sizeof(float_t)) unsigned char my_smem[];
+  float_t *shared = reinterpret_cast<float_t *>(my_smem);
+
+  float_t *s_A = shared;
+  float_t *s_B = shared + max_block_rows * d;
 
   for (int i = threadIdx.x; i < d * k; i += blockDim.x) {
     s_B[i] = B[i];


### PR DESCRIPTION
Cublas matrix multiplications that were used to calculate distances between data points and centroids are not optimized for tall and skinny matrices, which means that if either number of rows was very high compared to a number of dimensions or the number of clusters was very small the computation was very slow. After some manual benchmarking it seems that cublas is good if k is bigger than 16 and number of dimensions is bigger than 64.

A specialized matrix multiplication was introduced for that case, using shared memory. This probably still can be tuned to use shared memory and number of threads better but even with this simple improvement, we went from being x1.5-x2 slower than SKLearn to being x2.5-x4 faster.