### PR TITLE
Update Docker runtime files to use virtual env

### DIFF
--- a/Dockerfile-cuda9-runtime
+++ b/Dockerfile-cuda9-runtime
@@ -13,13 +13,10 @@ ENV LD_LIBRARY_PATH=$LD_LIBRARY_PATH:$LD_LIBRARY_PATH_MORE
 ENV CUDADIR=/usr/local/cuda/include/
 ENV OMP_NUM_THREADS=32
 ENV MKL_NUM_THREADS=32
-ENV HOME=/root
 ENV VECLIB_MAXIMUM_THREADS=32
-ENV PYENV_ROOT=$HOME/.pyenv
-ENV PATH=$PYENV_ROOT/bin:$PATH
 
-# Setup Repos
 RUN \
+  # Setup Repos
   apt-get update -y && \
   apt-get -y install curl apt-utils python-software-properties \
   software-properties-common iputils-ping wget cpio net-tools build-essential \
@@ -32,25 +29,23 @@ RUN \
   add-apt-repository ppa:fkrull/deadsnakes  && \
   apt-get update -yqq && \
   curl -sL https://deb.nodesource.com/setup_7.x | bash - && \
+  # Install H2o dependencies
   apt-get -y --no-install-recommends  install \
     python3.6 \
     python3.6-dev \
-    python3-pip \
-    python3-setuptools \
-    python3-wheel && \
+    virtualenv \
+    python3-pip && \
   update-alternatives --install /usr/bin/python python /usr/bin/python3.6 100 && \
   python -m pip install --upgrade pip && \
   apt-get clean && \
   rm -rf /var/cache/apt/* && \
-  apt-get install -y libopenblas-dev && \
-  apt-get install -y make build-essential libssl-dev zlib1g-dev libbz2-dev libreadline-dev libsqlite3-dev wget curl llvm libncurses5-dev libncursesw5-dev xz-utils tk-dev
+  apt-get install -y libopenblas-dev
 
 RUN \
-  git clone https://github.com/pyenv/pyenv.git ~/.pyenv && \
-  eval "$(/root/.pyenv/bin/pyenv init -)" && \
-  /root/.pyenv/bin/pyenv install 3.6.1 && \
-  /root/.pyenv/bin/pyenv global 3.6.1 && \
-  pip install setuptools --no-cache-dir && \
+  mkdir h2o4gpu_env && \
+  virtualenv --python=/usr/bin/python3.6 h2o4gpu_env && \
+  chmod -R o+w h2o4gpu_env && \
+  . h2o4gpu_env/bin/activate && \
   pip install --no-cache-dir --upgrade pip && \
   pip install --no-cache-dir --upgrade setuptools && \
   pip install --no-cache-dir --upgrade numpy && \
@@ -59,18 +54,17 @@ RUN \
 # Add requirements
 COPY requirements_runtime.txt requirements.txt
 RUN \
-  eval "$(/root/.pyenv/bin/pyenv init -)" && \
-  /root/.pyenv/bin/pyenv global 3.6.1 && \
+  . h2o4gpu_env/bin/activate && \
   pip install --no-cache-dir -r requirements.txt
 
 ADD src/interface_py/dist/ /dist
 RUN \
-  eval "$(/root/.pyenv/bin/pyenv init -)" && \
-  /root/.pyenv/bin/pyenv global 3.6.1 && \
+  . h2o4gpu_env/bin/activate && \
   pip install --no-cache-dir /dist/*.whl
 
 #Below will get the latest stable wheel file instead.
 #RUN \
+#  . h2o4gpu_env/bin/activate && \
 #  pip install --no-cache-dir https://s3.amazonaws.com/artifacts.h2o.ai/releases/stable/ai/h2o/h2o4gpu/0.0.4/h2o4gpu-0.0.4-py36-none-any.whl
 
 # Add a canned jupyter notebook demo to the container
@@ -80,6 +74,7 @@ COPY examples/py/demos/H2O4GPU_GLM.ipynb /jupyter/demos/H2O4GPU_GLM.ipynb
 COPY examples/py/demos/H2O4GPU_KMeans_Images.ipynb /jupyter/demos/H2O4GPU_KMeans_Images.ipynb
 COPY examples/py/xgboost_simple_demo.ipynb /jupyter/demos/xgboost_simple_demo.ipynb
 RUN \
+  . h2o4gpu_env/bin/activate && \
   cd /jupyter/demos && \
   chmod -R o+w /jupyter
 

--- a/Dockerfile-runtime
+++ b/Dockerfile-runtime
@@ -13,13 +13,10 @@ ENV LD_LIBRARY_PATH=$LD_LIBRARY_PATH:$LD_LIBRARY_PATH_MORE
 ENV CUDADIR=/usr/local/cuda/include/
 ENV OMP_NUM_THREADS=32
 ENV MKL_NUM_THREADS=32
-ENV HOME=/root
 ENV VECLIB_MAXIMUM_THREADS=32
-ENV PYENV_ROOT=$HOME/.pyenv
-ENV PATH=$PYENV_ROOT/bin:$PATH
 
-# Setup Repos
 RUN \
+  # Setup Repos
   apt-get update -y && \
   apt-get -y install curl apt-utils python-software-properties \
   software-properties-common iputils-ping wget cpio net-tools build-essential \
@@ -32,25 +29,23 @@ RUN \
   add-apt-repository ppa:fkrull/deadsnakes  && \
   apt-get update -yqq && \
   curl -sL https://deb.nodesource.com/setup_7.x | bash - && \
+  # Install H2o dependencies
   apt-get -y --no-install-recommends  install \
     python3.6 \
     python3.6-dev \
-    python3-pip \
-    python3-setuptools \
-    python3-wheel && \
+    virtualenv \
+    python3-pip && \
   update-alternatives --install /usr/bin/python python /usr/bin/python3.6 100 && \
   python -m pip install --upgrade pip && \
   apt-get clean && \
   rm -rf /var/cache/apt/* && \
-  apt-get install -y libopenblas-dev && \
-  apt-get install -y make build-essential libssl-dev zlib1g-dev libbz2-dev libreadline-dev libsqlite3-dev wget curl llvm libncurses5-dev libncursesw5-dev xz-utils tk-dev
+  apt-get install -y libopenblas-dev
 
 RUN \
-  git clone https://github.com/pyenv/pyenv.git ~/.pyenv && \
-  eval "$(/root/.pyenv/bin/pyenv init -)" && \
-  /root/.pyenv/bin/pyenv install 3.6.1 && \
-  /root/.pyenv/bin/pyenv global 3.6.1 && \
-  pip install setuptools --no-cache-dir && \
+  mkdir h2o4gpu_env && \
+  virtualenv --python=/usr/bin/python3.6 h2o4gpu_env && \
+  chmod -R o+w h2o4gpu_env && \
+  . h2o4gpu_env/bin/activate && \
   pip install --no-cache-dir --upgrade pip && \
   pip install --no-cache-dir --upgrade setuptools && \
   pip install --no-cache-dir --upgrade numpy && \
@@ -59,18 +54,17 @@ RUN \
 # Add requirements
 COPY requirements_runtime.txt requirements.txt
 RUN \
-  eval "$(/root/.pyenv/bin/pyenv init -)" && \
-  /root/.pyenv/bin/pyenv global 3.6.1 && \
+  . h2o4gpu_env/bin/activate && \
   pip install --no-cache-dir -r requirements.txt
 
 ADD src/interface_py/dist/ /dist
 RUN \
-  eval "$(/root/.pyenv/bin/pyenv init -)" && \
-  /root/.pyenv/bin/pyenv global 3.6.1 && \
+  . h2o4gpu_env/bin/activate && \
   pip install --no-cache-dir /dist/*.whl
 
 #Below will get the latest stable wheel file instead.
 #RUN \
+#  . h2o4gpu_env/bin/activate && \
 #  pip install --no-cache-dir https://s3.amazonaws.com/artifacts.h2o.ai/releases/stable/ai/h2o/h2o4gpu/0.0.4/h2o4gpu-0.0.4-py36-none-any.whl
 
 # Add a canned jupyter notebook demo to the container
@@ -80,6 +74,7 @@ COPY examples/py/demos/H2O4GPU_GLM.ipynb /jupyter/demos/H2O4GPU_GLM.ipynb
 COPY examples/py/demos/H2O4GPU_KMeans_Images.ipynb /jupyter/demos/H2O4GPU_KMeans_Images.ipynb
 COPY examples/py/xgboost_simple_demo.ipynb /jupyter/demos/xgboost_simple_demo.ipynb
 RUN \
+  . h2o4gpu_env/bin/activate && \
   cd /jupyter/demos && \
   chmod -R o+w /jupyter
 


### PR DESCRIPTION
* Utilize virtual env for Docker runtime images as these images are mainly used to set up environments for jupyter notebooks/demos.
* We can revisit pyenv later if it is absolutely needed.