### PR TITLE
Add Dockerfile-runtime step for CUDA 8/9

### DIFF
--- a/Dockerfile-cuda9-runtime
+++ b/Dockerfile-cuda9-runtime
@@ -57,22 +57,16 @@ RUN \
   . h2o4gpu_env/bin/activate && \
   pip install --no-cache-dir -r requirements.txt
 
-ADD src/interface_py/dist/ /dist
+#Below will get the latest stable wheel file instead.
 RUN \
   . h2o4gpu_env/bin/activate && \
-  pip install --no-cache-dir /dist/*.whl
-
-#Below will get the latest stable wheel file instead.
-#RUN \
-#  . h2o4gpu_env/bin/activate && \
-#  pip install --no-cache-dir https://s3.amazonaws.com/artifacts.h2o.ai/releases/stable/ai/h2o/h2o4gpu/0.0.4/h2o4gpu-0.0.4-py36-none-any.whl
+  pip install --no-cache-dir https://s3.amazonaws.com/artifacts.h2o.ai/releases/bleeding-edge/ai/h2o/h2o4gpu/0.0.4_nonccl_cuda9/h2o4gpu-0.0.4-py36-none-any.whl
 
 # Add a canned jupyter notebook demo to the container
 RUN \
   mkdir -p jupyter/demos
-COPY examples/py/demos/H2O4GPU_GLM.ipynb /jupyter/demos/H2O4GPU_GLM.ipynb
-COPY examples/py/demos/H2O4GPU_KMeans_Images.ipynb /jupyter/demos/H2O4GPU_KMeans_Images.ipynb
-COPY examples/py/xgboost_simple_demo.ipynb /jupyter/demos/xgboost_simple_demo.ipynb
+COPY examples/py/demos /jupyter/demos/
+
 RUN \
   . h2o4gpu_env/bin/activate && \
   cd /jupyter/demos && \

--- a/Dockerfile-runtime
+++ b/Dockerfile-runtime
@@ -57,22 +57,16 @@ RUN \
   . h2o4gpu_env/bin/activate && \
   pip install --no-cache-dir -r requirements.txt
 
-ADD src/interface_py/dist/ /dist
+#Below will get the latest stable wheel file instead.
 RUN \
   . h2o4gpu_env/bin/activate && \
-  pip install --no-cache-dir /dist/*.whl
-
-#Below will get the latest stable wheel file instead.
-#RUN \
-#  . h2o4gpu_env/bin/activate && \
-#  pip install --no-cache-dir https://s3.amazonaws.com/artifacts.h2o.ai/releases/stable/ai/h2o/h2o4gpu/0.0.4/h2o4gpu-0.0.4-py36-none-any.whl
+  pip install --no-cache-dir https://s3.amazonaws.com/artifacts.h2o.ai/releases/bleeding-edge/ai/h2o/h2o4gpu/0.0.4/h2o4gpu-0.0.4-py36-none-any.whl
 
 # Add a canned jupyter notebook demo to the container
 RUN \
   mkdir -p jupyter/demos
-COPY examples/py/demos/H2O4GPU_GLM.ipynb /jupyter/demos/H2O4GPU_GLM.ipynb
-COPY examples/py/demos/H2O4GPU_KMeans_Images.ipynb /jupyter/demos/H2O4GPU_KMeans_Images.ipynb
-COPY examples/py/xgboost_simple_demo.ipynb /jupyter/demos/xgboost_simple_demo.ipynb
+COPY examples/py/demos /jupyter/demos/
+
 RUN \
   . h2o4gpu_env/bin/activate && \
   cd /jupyter/demos && \

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -226,7 +226,7 @@ pipeline {
             }
         }
 
-        stage('Publish to Runtime Docker for CUDA 8 to S3') {
+        stage('Publish Runtime Docker for CUDA 8 to S3') {
             agent {
                 label "linux"
             }
@@ -257,7 +257,7 @@ pipeline {
 
                         if (isBleedingEdge()) {
                             s3up {
-                                localArtifact = 'src/interface_py/dist/h2o4gpu-*-py36-none-any.whl'
+                                localArtifact = 'h2o4gpu-cuda8-runtime.tar.gz'
                                 artifactId = "h2o4gpu"
                                 majorVersion = _majorVersion
                                 buildVersion = _buildVersion

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -190,6 +190,87 @@ pipeline {
             }
         }
 
+        stage('Build Runtime Docker for CUDA 8') {
+            agent {
+                label "nvidia-docker && (mr-dl11||mr-dl16||mr-dl10)"
+            }
+
+            steps {
+                dumpInfo 'Linux Build Info'
+                // Do checkout
+                retryWithTimeout(100 /* seconds */, 3 /* retries */) {
+                    deleteDir()
+                    checkout([
+                            $class                           : 'GitSCM',
+                            branches                         : scm.branches,
+                            doGenerateSubmoduleConfigurations: false,
+                            extensions                       : scm.extensions + [[$class: 'SubmoduleOption', disableSubmodules: true, recursiveSubmodules: false, reference: '', trackingSubmodules: false, shallow: true]],
+                            submoduleCfg                     : [],
+                            userRemoteConfigs                : scm.userRemoteConfigs])
+                }
+
+                script {
+                    CONTAINER_NAME = "h2o4gpu${SAFE_CHANGE_ID}-${env.BUILD_ID}"
+                    // Get source code
+                    withCredentials([[$class: 'AmazonWebServicesCredentialsBinding', credentialsId: "awsArtifactsUploader"]]) {
+                        sh """
+                                nvidia-docker build  -t opsh2oai/h2o4gpu-cuda8-runtime:latest -f Dockerfile-runtime .
+                                nvidia-docker save opsh2oai/h2o4gpu-cuda8-runtime > h2o4gpu-cuda8-runtime.tar
+                                gzip  h2o4gpu-cuda8-runtime.tar
+                            """
+                        stash includes: 'h2o4gpu-cuda8-runtime.tar.gz', name: 'docker-cuda8-runtime'
+                        // Archive artifacts
+                        arch 'h2o4gpu-cuda8-runtime.tar.gz'
+                    }
+                }
+            }
+        }
+
+        stage('Publish to Runtime Docker for CUDA 8 to S3') {
+            agent {
+                label "linux"
+            }
+
+            steps {
+                unstash 'docker-cuda8-runtime'
+                unstash 'version_info'
+                withCredentials([[$class: 'AmazonWebServicesCredentialsBinding', credentialsId: "awsArtifactsUploader"]]) {
+                    script {
+                        // Load the version file content
+                        def versionTag = utilsLib.getCommandOutput("cat build/VERSION.txt | tr '+' '-'")
+                        def version = utilsLib.fragmentVersion(versionTag)
+                        def _majorVersion = version[0]
+                        def _buildVersion = version[1]
+                        version = null // This is necessary, else version:Tuple will be serialized
+
+                        if (isRelease()) {
+                            s3up {
+                                localArtifact = 'h2o4gpu-cuda8-runtime.tar.gz'
+                                artifactId = "h2o4gpu"
+                                majorVersion = _majorVersion
+                                buildVersion = _buildVersion
+                                keepPrivate = false
+                                remoteArtifactBucket = "s3://artifacts.h2o.ai/releases/stable"
+                            }
+                            sh "s3cmd setacl --acl-public s3://artifacts.h2o.ai/releases/stable/ai/h2o/h2o4gpu/${versionTag}/h2o4gpu-cuda8-runtime.tar.gz"
+                        }
+
+                        if (isBleedingEdge()) {
+                            s3up {
+                                localArtifact = 'src/interface_py/dist/h2o4gpu-*-py36-none-any.whl'
+                                artifactId = "h2o4gpu"
+                                majorVersion = _majorVersion
+                                buildVersion = _buildVersion
+                                keepPrivate = false
+                                remoteArtifactBucket = "s3://artifacts.h2o.ai/releases/bleeding-edge"
+                            }
+                            sh "s3cmd setacl --acl-public s3://artifacts.h2o.ai/releases/bleeding-edge/ai/h2o/h2o4gpu/${versionTag}/h2o4gpu-cuda8-runtime.tar.gz"
+                        }
+                    }
+                }
+            }
+        }
+
         stage('Build on Linux nonccl xgboost') {
             agent {
                 label "nvidia-docker && (mr-dl11||mr-dl16||mr-dl10)"

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -271,6 +271,87 @@ pipeline {
             }
         }
 
+        stage('Build Runtime Docker for CUDA 9') {
+            agent {
+                label "nvidia-docker && (mr-dl11||mr-dl16||mr-dl10)"
+            }
+
+            steps {
+                dumpInfo 'Linux Build Info'
+                // Do checkout
+                retryWithTimeout(100 /* seconds */, 3 /* retries */) {
+                    deleteDir()
+                    checkout([
+                            $class                           : 'GitSCM',
+                            branches                         : scm.branches,
+                            doGenerateSubmoduleConfigurations: false,
+                            extensions                       : scm.extensions + [[$class: 'SubmoduleOption', disableSubmodules: true, recursiveSubmodules: false, reference: '', trackingSubmodules: false, shallow: true]],
+                            submoduleCfg                     : [],
+                            userRemoteConfigs                : scm.userRemoteConfigs])
+                }
+
+                script {
+                    CONTAINER_NAME = "h2o4gpu${SAFE_CHANGE_ID}-${env.BUILD_ID}"
+                    // Get source code
+                    withCredentials([[$class: 'AmazonWebServicesCredentialsBinding', credentialsId: "awsArtifactsUploader"]]) {
+                        sh """
+                                nvidia-docker build  -t opsh2oai/h2o4gpu-cuda9-runtime:latest -f Dockerfile-cuda9-runtime .
+                                nvidia-docker save opsh2oai/h2o4gpu-cuda9-runtime > h2o4gpu-cuda9-runtime.tar
+                                gzip  h2o4gpu-cuda9-runtime.tar
+                            """
+                        stash includes: 'h2o4gpu-cuda9-runtime.tar.gz', name: 'docker-cuda9-runtime'
+                        // Archive artifacts
+                        arch 'h2o4gpu-cuda9-runtime.tar.gz'
+                    }
+                }
+            }
+        }
+
+        stage('Publish Runtime Docker for CUDA 9 to S3') {
+            agent {
+                label "linux"
+            }
+
+            steps {
+                unstash 'docker-cuda9-runtime'
+                unstash 'version_info'
+                withCredentials([[$class: 'AmazonWebServicesCredentialsBinding', credentialsId: "awsArtifactsUploader"]]) {
+                    script {
+                        // Load the version file content
+                        def versionTag = utilsLib.getCommandOutput("cat build/VERSION.txt | tr '+' '-'")
+                        def version = utilsLib.fragmentVersion(versionTag)
+                        def _majorVersion = version[0]
+                        def _buildVersion = version[1]
+                        version = null // This is necessary, else version:Tuple will be serialized
+
+                        if (isRelease()) {
+                            s3up {
+                                localArtifact = 'h2o4gpu-cuda9-runtime.tar.gz'
+                                artifactId = "h2o4gpu"
+                                majorVersion = _majorVersion
+                                buildVersion = _buildVersion
+                                keepPrivate = false
+                                remoteArtifactBucket = "s3://artifacts.h2o.ai/releases/stable"
+                            }
+                            sh "s3cmd setacl --acl-public s3://artifacts.h2o.ai/releases/stable/ai/h2o/h2o4gpu/${versionTag}/h2o4gpu-cuda9-runtime.tar.gz"
+                        }
+
+                        if (isBleedingEdge()) {
+                            s3up {
+                                localArtifact = 'h2o4gpu-cuda9-runtime.tar.gz'
+                                artifactId = "h2o4gpu"
+                                majorVersion = _majorVersion
+                                buildVersion = _buildVersion
+                                keepPrivate = false
+                                remoteArtifactBucket = "s3://artifacts.h2o.ai/releases/bleeding-edge"
+                            }
+                            sh "s3cmd setacl --acl-public s3://artifacts.h2o.ai/releases/bleeding-edge/ai/h2o/h2o4gpu/${versionTag}/h2o4gpu-cuda9=-runtime.tar.gz"
+                        }
+                    }
+                }
+            }
+        }
+
         stage('Build on Linux nonccl xgboost') {
             agent {
                 label "nvidia-docker && (mr-dl11||mr-dl16||mr-dl10)"


### PR DESCRIPTION
* This PR adds four steps to the Jenkins pipeline:

1. It will build a Dockerfile-runtime image for CUDA 8 & 9 with the latest bleed edge .whl file.
2. It will upload the above mentioned images as a .tar.gz files to S3.