### PR TITLE
Fixes #194 #278 #279 and perf improvements

### DIFF
--- a/examples/cpp/kmeans_driver.cpp
+++ b/examples/cpp/kmeans_driver.cpp
@@ -51,14 +51,13 @@ int main(int argc, char **argv) {
   int verbose=1;
   const char ord='r';
   int init_from_data=1;//true as set above, otherwise internally will set initial centroids "smartly"
-  int init_data=2; // randomly (without replacement) select from input
   int seed=12345;
   int dopredict = 0;
 
   std::vector<real_t> centroids(1);
   centroids[0] = static_cast<real_t>(drand48());
 
-  h2o4gpukmeans::makePtr_dense<real_t>(dopredict, verbose, seed, gpu_id, n_gpu, rows, cols, ord, k, max_iterations, init_from_data, init_data, threshold, &data[0], &centroids[0], &preds, &pred_labels);
+  h2o4gpukmeans::makePtr_dense<real_t>(dopredict, verbose, seed, gpu_id, n_gpu, rows, cols, ord, k, max_iterations, init_from_data, threshold, &data[0], &centroids[0], &preds, &pred_labels);
 
   // report something about centroids that site in res as k*cols data block
 #endif

--- a/src/common/logger.h
+++ b/src/common/logger.h
@@ -20,6 +20,6 @@
 #define log_info(desired_level, ...)  log(desired_level, H2O4GPU_LOG_INFO,  __FILE__, __LINE__, __VA_ARGS__)
 #define log_warn(desired_level, ...)  log(desired_level, H2O4GPU_LOG_WARN,  __FILE__, __LINE__, __VA_ARGS__)
 #define log_debug(desired_level, ...) log(desired_level, H2O4GPU_LOG_DEBUG, __FILE__, __LINE__, __VA_ARGS__)
-#define log_verbose(desired_level, ...) log(desired_level, H2O4GPULOG_VERBOSE, __FILE__, __LINE__, __VA_ARGS__)
+#define log_verbose(desired_level, ...) log(desired_level, H2O4GPU_LOG_VERBOSE, __FILE__, __LINE__, __VA_ARGS__)
 
 void log(int desired_level, int level, const char *file, int line, const char *fmt, ...);

--- a/src/common/utils.cpp
+++ b/src/common/utils.cpp
@@ -3,6 +3,7 @@
  * License   Apache License Version 2.0 (see LICENSE for details)
  */
 #include "utils.h"
+#include "logger.h"
 
 template<typename T>
 void self_dot(std::vector<T> array_in, int n, int dim,

--- a/src/cpu/h2o4gpukmeans.cpp
+++ b/src/cpu/h2o4gpukmeans.cpp
@@ -198,7 +198,7 @@ namespace h2o4gpukmeans {
     template<typename T>
     int kmeans_fit(int verbose, int seed, int cpu_idtry, int n_cputry,
                    size_t rows, size_t cols, const char ord, int k, int max_iterations,
-                   int init_from_data, int init_data, T threshold,
+                   int init_from_data, T threshold,
                    const T *srcdata, void **pred_centroids, void **pred_labels) {
         if (rows > std::numeric_limits<int>::max()) {
             fprintf(stderr, "rows > %d not implemented\n", std::numeric_limits<int>::max());
@@ -258,13 +258,7 @@ namespace h2o4gpukmeans {
         std::random_shuffle(v.begin(), v.end());
 
         for (int q = 0; q < n_cpu; q++) {
-            if (init_data == 0) { // random (for testing)
-                random_data<T>(verbose, *data[q], n / n_cpu, d);
-            } else if (init_data == 1) { // shard by row
-                nonrandom_data(verbose, ord, *data[q], &srcdata[0], q, n, n / n_cpu, d);
-            } else { // shard by randomly (without replacement) selected by row
-                nonrandom_data_new(verbose, v, ord, *data[q], &srcdata[0], q, n, n / n_cpu, d);
-            }
+            nonrandom_data(verbose, ord, *data[q], &srcdata[0], q, n, n / n_cpu, d);
         }
         // get non-random centroids on 1 cpu, then share with rest.
         if (init_from_data == 0) {
@@ -459,12 +453,12 @@ namespace h2o4gpukmeans {
 
     template<typename T>
     int makePtr_dense(int dopredict, int verbose, int seed, int cpu_idtry, int n_cputry, size_t rows, size_t cols,
-                      const char ord, int k, int max_iterations, int init_from_data, int init_data,
+                      const char ord, int k, int max_iterations, int init_from_data,
                       T threshold, const T *srcdata, const T *centroids,
                       void **pred_centroids, void **pred_labels) {
         if (dopredict == 0) {
             return kmeans_fit(verbose, seed, cpu_idtry, n_cputry, rows, cols,
-                              ord, k, max_iterations, init_from_data, init_data, threshold,
+                              ord, k, max_iterations, init_from_data, threshold,
                               srcdata, pred_centroids, pred_labels);
         } else {
             return kmeans_predict(verbose, cpu_idtry, n_cputry, rows, cols,
@@ -476,27 +470,27 @@ namespace h2o4gpukmeans {
     template
     int makePtr_dense<float>(int dopredict, int verbose, int seed, int cpu_idtry, int n_cputry, size_t rows, size_t cols,
                              const char ord, int k, int max_iterations, int init_from_data,
-                             int init_data, float threshold, const float *srcdata,
+                             float threshold, const float *srcdata,
                              const float *centroids, void **pred_centroids, void **pred_labels);
 
     template
     int makePtr_dense<double>(int dopredict, int verbose, int seed, int cpu_idtry, int n_cputry, size_t rows, size_t cols,
                               const char ord, int k, int max_iterations, int init_from_data,
-                              int init_data, double threshold, const double *srcdata,
+                              double threshold, const double *srcdata,
                               const double *centroids, void **pred_centroids, void **pred_labels);
 
     template
     int kmeans_fit<float>(int verbose, int seed, int cpu_idtry, int n_cputry,
                           size_t rows, size_t cols,
                           const char ord, int k, int max_iterations,
-                          int init_from_data, int init_data, float threshold,
+                          int init_from_data, float threshold,
                           const float *srcdata, void **pred_centroids, void **pred_labels);
 
     template
     int kmeans_fit<double>(int verbose, int seed, int cpu_idtry, int n_cputry,
                            size_t rows, size_t cols,
                            const char ord, int k, int max_iterations,
-                           int init_from_data, int init_data, double threshold,
+                           int init_from_data, double threshold,
                            const double *srcdata, void **pred_centroids, void **pred_labels);
 
     template
@@ -549,20 +543,20 @@ extern "C" {
 // Fit and Predict
 int make_ptr_float_kmeans(int dopredict, int verbose, int seed, int cpu_id, int n_cpu, size_t mTrain, size_t n,
                           const char ord, int k, int max_iterations, int init_from_data,
-                          int init_data, float threshold, const float *srcdata,
+                          float threshold, const float *srcdata,
                           const float *centroids, void **pred_centroids, void **pred_labels) {
     return h2o4gpukmeans::makePtr_dense<float>(dopredict, verbose, seed, cpu_id, n_cpu, mTrain, n, ord, k,
-                                                max_iterations, init_from_data, init_data, threshold,
+                                                max_iterations, init_from_data, threshold,
                                                 srcdata, centroids,
                                                 pred_centroids, pred_labels);
 }
 
 int make_ptr_double_kmeans(int dopredict, int verbose, int seed, int cpu_id, int n_cpu, size_t mTrain, size_t n,
                            const char ord, int k, int max_iterations, int init_from_data,
-                           int init_data, double threshold, const double *srcdata,
+                           double threshold, const double *srcdata,
                            const double *centroids, void **pred_centroids, void **pred_labels) {
     return h2o4gpukmeans::makePtr_dense<double>(dopredict, verbose, seed, cpu_id, n_cpu, mTrain, n, ord, k,
-                                                 max_iterations, init_from_data, init_data, threshold,
+                                                 max_iterations, init_from_data, threshold,
                                                  srcdata, centroids,
                                                  pred_centroids, pred_labels);
 }

--- a/src/cpu/h2o4gpukmeans.cpp
+++ b/src/cpu/h2o4gpukmeans.cpp
@@ -279,9 +279,9 @@ namespace h2o4gpukmeans {
 
         double t0 = timer<double>();
         int masterq = 0;
-        int status = kmeans::kmeans<T>(verbose, &flag, n, d, k, *data[masterq], *labels[masterq],
-                                       *l_centroids[masterq], max_iterations, init_from_data, threshold);
-        if (status) return (status);
+        kmeans::kmeans<T>(verbose, &flag, n, d, k, *data[masterq], *labels[masterq],
+                          *l_centroids[masterq], max_iterations, init_from_data, threshold);
+
         double timefit = static_cast<double>(timer<double>() - t0);
 
         std::cout << "  Time fit: " << timefit << " s" << std::endl;

--- a/src/gpu/kmeans/kmeans_centroids.h
+++ b/src/gpu/kmeans/kmeans_centroids.h
@@ -147,7 +147,6 @@ void find_centroids(int q, int n, int d, int k,
 
 #if(CHECK)
   gpuErrchk(cudaGetLastError());
-  gpuErrchk(cudaDeviceSynchronize());
 #endif
 
   // Need to zero this - the algo uses this array to accumulate values for each centroid
@@ -171,7 +170,6 @@ void find_centroids(int q, int n, int d, int k,
 
   #if(CHECK)
   gpuErrchk(cudaGetLastError());
-  gpuErrchk(cudaDeviceSynchronize());
   #endif
 
   // Scaling should take place on the GPU if n_gpus=1 so we don't
@@ -188,7 +186,6 @@ void find_centroids(int q, int n, int d, int k,
 
     #if(CHECK)
     gpuErrchk(cudaGetLastError());
-    gpuErrchk(cudaDeviceSynchronize());
     #endif
 
     //Averages the centroids

--- a/src/gpu/kmeans/kmeans_general.h
+++ b/src/gpu/kmeans/kmeans_general.h
@@ -14,3 +14,13 @@
 #define gpuErrchk(ans) { gpu_assert((ans), __FILE__, __LINE__); }
 #define safe_cuda(ans) throw_on_cuda_error((ans), __FILE__, __LINE__);
 #define safe_cublas(ans) throw_on_cublas_error((ans), __FILE__, __LINE__);
+
+#define CUDACHECK(cmd) do {                           \
+    cudaError_t e = cmd;                              \
+    if( e != cudaSuccess ) {                          \
+      printf("Cuda failure %s:%d '%s'\n",             \
+             __FILE__,__LINE__,cudaGetErrorString(e));\
+      fflush( stdout );                               \
+      exit(EXIT_FAILURE);                             \
+    }                                                 \
+  } while(0)

--- a/src/gpu/kmeans/kmeans_h2o4gpu.cu
+++ b/src/gpu/kmeans/kmeans_h2o4gpu.cu
@@ -768,14 +768,9 @@ int kmeans_fit(int verbose, int seed, int gpu_idtry, int n_gputry,
 
   double t0 = timer<double>();
 
-  int status = kmeans::kmeans<T>(verbose, &flaggpu, rows, cols, k, data, labels, d_centroids, distances, data_dots,
-                                 dList, n_gpu, max_iterations, threshold, true);
+  kmeans::kmeans<T>(verbose, &flaggpu, rows, cols, k, data, labels, d_centroids, distances, data_dots,
+                    dList, n_gpu, max_iterations, threshold, true);
 
-  if (status) {
-    fprintf(stderr, "KMeans status was %d\n", status);
-    fflush(stderr);
-    return (status);
-  }
 
   double timefit = static_cast<double>(timer<double>() - t0);
 

--- a/src/gpu/kmeans/kmeans_impl.h
+++ b/src/gpu/kmeans/kmeans_impl.h
@@ -78,10 +78,7 @@ int kmeans(
   T *d_distance_sum[MAX_NGPUS];
 
   for (int q = 0; q < n_gpu; q++) {
-    if (verbose) {
-      fprintf(stderr, "Before kmeans() Allocation: gpu: %d\n", q);
-      fflush(stderr);
-    }
+    log_debug(verbose, "Before kmeans() Allocation: gpu: %d", q);
 
     safe_cuda(cudaSetDevice(dList[q]));
     safe_cuda(cudaMalloc(&d_distance_sum[q], sizeof(T)));
@@ -109,25 +106,13 @@ int kmeans(
       //throw std::runtime_error(ss.str());
     }
 
-    if (verbose) {
-      fprintf(stderr, "Before Create and save range for initializing labels: gpu: %d\n", q);
-      fflush(stderr);
-    }
     //Create and save "range" for initializing labels
     thrust::copy(thrust::counting_iterator<int>(0),
                  thrust::counting_iterator<int>(n / n_gpu),
                  (*range[q]).begin());
-
-    if (verbose) {
-      fprintf(stderr, "Before make_self_dots: gpu: %d\n", q);
-      fflush(stderr);
-    }
   }
 
-  if (verbose) {
-    fprintf(stderr, "Before kmeans() Iterations\n");
-    fflush(stderr);
-  }
+  log_debug(verbose, "Before kmeans() Iterations");
 
   int i = 0;
   bool done = false;
@@ -178,7 +163,7 @@ int kmeans(
       // Zero the centroids only if any of the GPUs actually updated them
       for (int p = 0; p < k; p++) {
         for (int r = 0; r < d; r++) {
-          if (h_counts_tmp[p] != 0) {
+          if (h_counts[p] != 0) {
             h_centroids[p * d + r] = 0.0;
           }
         }
@@ -190,7 +175,7 @@ int kmeans(
         detail::streamsync(dList[q]);
         for (int p = 0; p < k; p++) {
           for (int r = 0; r < d; r++) {
-            if (h_counts_tmp[p] != 0) {
+            if (h_counts[p] != 0) {
               h_centroids[p * d + r] += h_centroids_tmp[p * d + r];
             }
           }
@@ -266,12 +251,9 @@ int kmeans(
     delete (indices[q]);
   }
 
-  if (verbose) {
-    fprintf(stderr,
-            "Iterations: %d\n", i);
-    fflush(stderr);
-  }
-  return 0;
+  log_debug(verbose, "Iterations: %d", i);
+
+  return i;
 }
 
 }

--- a/src/include/h2o4gpukmeans.h
+++ b/src/include/h2o4gpukmeans.h
@@ -43,14 +43,14 @@ class H2O4GPUKMeansCPU {
 
 template<typename T>
 int makePtr_dense(int dopredict, int verbose, int seed, int gpu_id, int n_gpu, size_t rows, size_t cols,
-                  const char ord, int k, int max_iterations, int init_from_data, int init_data,
+                  const char ord, int k, int max_iterations, int init_from_data,
                   T threshold, const T *srcdata, const T *centroids,
                   void **pred_centroids, void **pred_labels);
 
 template<typename T>
 int makePtr_dense_cpu(int dopredict, int verbose, int seed, int cpu_id, int n_cpu, size_t rows, size_t cols,
                       const char ord, int k, int max_iterations, int init_from_data,
-                      int init_data, T threshold, const T *srcdata, const T *centroids,
+                      T threshold, const T *srcdata, const T *centroids,
                       void **pred_centroids, void **pred_labels);
 
 template<typename T>

--- a/src/interface_py/h2o4gpu/libs/lib_kmeans.py
+++ b/src/interface_py/h2o4gpu/libs/lib_kmeans.py
@@ -52,7 +52,6 @@ def _load_kmeans_lib(lib_path):
             c_int,  # n_clusters
             c_int,  # max_iter
             c_int,  # init_from_data
-            c_int,  # init_data
             c_float,  # tol
             c_float_p,  # data
             c_float_p,  # centers
@@ -73,7 +72,6 @@ def _load_kmeans_lib(lib_path):
             c_int,  # n_clusters
             c_int,  # max_iter
             c_int,  # init_from_data
-            c_int,  # init_data
             c_double,  # tol
             c_double_p,  # data
             c_double_p,  # centers

--- a/src/interface_py/test.sh
+++ b/src/interface_py/test.sh
@@ -1,0 +1,12 @@
+#!/bin/sh
+
+status=0
+for py in `find h2o4gpu -name "*.py" -type f`; do 
+	pylint --rcfile=../../tools/pylintrc -rn $py; 
+	tmp=$?
+	if [ $tmp -ne 0 ]; then
+		echo $status
+		status=$tmp
+	fi
+done
+exit $status


### PR DESCRIPTION
* Remove init_data - the algorithm does not rely on data order but shuffling the initial data has a performance overhead (needs to copy data in a loop instead of a single memcpy call, needs to sort the output labels into the original order)
* Fixes bug with selectstrat - not all data was copied to the device
* Don't use fromiter for ctype pointers when casting back in python - very slow
* Use thrust vector contructor to copy data instead of running it in a loop
* Don't use type T for weights in kmeans++, takes unecessary space
* Use addAtomic for int when counting weights instead of for float/double - much faster
* Pairwise distance calculation is done in a batched manner if there's not enough memory on the GPU - now we are mainly limited by `rows * cols` size.

Batched pairwise computation code is still a bit copy pasted here and there because `nvcc` doesn't let me to put a `__device__` lambda inside a regular lambda...