### PR TITLE
Related to #284 - temporarily remove type checks

### DIFF
--- a/src/interface_py/h2o4gpu/solvers/elastic_net.py
+++ b/src/interface_py/h2o4gpu/solvers/elastic_net.py
@@ -786,8 +786,7 @@ class ElasticNetH2O(object):
 
         return self
 
-#TODO Add typechecking
-
+    # pylint: disable=unused-argument
     def predict_ptr(self,
                     valid_xptr=None,
                     valid_yptr=None,
@@ -850,8 +849,7 @@ class ElasticNetH2O(object):
 
         return self.valid_pred_vs_alphapure  # something like valid_y
 
-#TODO Add type checking
-
+    # pylint: disable=unused-argument
     def fit_predict(self,
                     train_x,
                     train_y,
@@ -902,8 +900,7 @@ class ElasticNetH2O(object):
                 free_input_data=free_input_data)
         return self.prediction  # something like valid_y
 
-#TODO Add type checking
-
+    # pylint: disable=unused-argument
     def fit_predict_ptr(self,
                         m_train,
                         n,

--- a/src/interface_py/h2o4gpu/solvers/elastic_net.py
+++ b/src/interface_py/h2o4gpu/solvers/elastic_net.py
@@ -18,8 +18,6 @@ from ..solvers.utils import _setter
 from ..libs.lib_elastic_net import GPUlib, CPUlib
 from ..solvers.utils import prepare_and_upload_data, free_data, free_sols
 from ..util.gpu import device_count
-from ..typecheck.typechecks import (assert_is_type, numpy_ndarray,
-                                    pandas_dataframe)
 
 
 class ElasticNetH2O(object):
@@ -131,39 +129,13 @@ class ElasticNetH2O(object):
                  lambdas=None,
                  double_precision=None,
                  order=None):
-        ##############################
-        #asserts
-        assert_is_type(n_threads, int, None, type(np.int32), type(np.int64))
-        assert_is_type(gpu_id, int, type(np.int32), type(np.int64))
-        assert_is_type(n_gpus, int, type(np.int32), type(np.int64))
-        assert_is_type(fit_intercept, bool)
-        assert_is_type(lambda_min_ratio, float,
-                       type(np.float16), type(np.float32), type(np.float64))
-        assert_is_type(n_lambdas, int, type(np.int32), type(np.int64))
-        assert_is_type(n_folds, int, type(np.int32), type(np.int64))
-        assert_is_type(n_alphas, int, type(np.int32), type(np.int64))
-        assert_is_type(tol, float,
-                       type(np.float16), type(np.float32), type(np.float64))
-        assert_is_type(tol_seek_factor, float,
-                       type(np.float16), type(np.float32), type(np.float64))
-        assert_is_type(lambda_stop_early, bool)
-        assert_is_type(glm_stop_early, bool)
-        assert_is_type(glm_stop_early_error_fraction, float,
-                       type(np.float16), type(np.float32), type(np.float64))
-        assert_is_type(max_iter, int, type(np.int32), type(np.int64))
-        assert_is_type(verbose, int, type(np.int32), type(np.int64))
-        assert_is_type(family, str)
         assert family in ['logistic',
                           'elasticnet'], \
             "family should be 'logistic' or 'elasticnet' but got " + family
-        assert_is_type(lambda_max, float, int, None)
-        assert_is_type(alpha_max, float, int, None)
-        assert_is_type(alpha_min, float, int, None)
 
         self.double_precision = double_precision
 
         if order is not None:
-            assert_is_type(order, str)
             assert order in ['r',
                              'c'], \
                 "Order should be set to 'r' or 'c' but got " + order
@@ -300,13 +272,6 @@ class ElasticNetH2O(object):
             at the end of fit(). Default is 1.
         """
 
-        assert_is_type(train_x, numpy_ndarray, pandas_dataframe, None)
-        assert_is_type(train_y, numpy_ndarray, pandas_dataframe, None)
-        assert_is_type(valid_x, numpy_ndarray, pandas_dataframe, None)
-        assert_is_type(valid_y, numpy_ndarray, pandas_dataframe, None)
-        assert_is_type(sample_weight, numpy_ndarray, pandas_dataframe, None)
-        assert_is_type(free_input_data, int)
-
         source_dev = 0
         if not (train_x is None and train_y is None and valid_x is None and
                 valid_y is None and sample_weight is None):
@@ -359,11 +324,6 @@ class ElasticNetH2O(object):
         :param int free_input_data : Indicate if input data should be freed at
             the end of fit(). Default is 1.
         """
-
-        assert_is_type(valid_x, numpy_ndarray, pandas_dataframe, None)
-        assert_is_type(valid_y, numpy_ndarray, pandas_dataframe, None)
-        assert_is_type(sample_weight, numpy_ndarray, pandas_dataframe, None)
-        assert_is_type(free_input_data, int)
 
         source_dev = 0
         if not (valid_x is None and valid_y is None and sample_weight is None):
@@ -543,19 +503,6 @@ class ElasticNetH2O(object):
         :param int free_input_data : Indicate if input data should be freed at
             the end of fit(). Default is 1.
         """
-
-        assert_is_type(source_dev, int, None)
-        assert_is_type(m_train, int, None)
-        assert_is_type(n, int, None)
-        assert_is_type(double_precision, float, int, None)
-        assert_is_type(order, int, str, None)
-        assert_is_type(a, c_void_p, None)
-        assert_is_type(b, c_void_p, None)
-        assert_is_type(c, c_void_p, None)
-        assert_is_type(d, c_void_p, None)
-        assert_is_type(e, c_void_p, None)
-        assert_is_type(do_predict, int, None)
-        assert_is_type(free_input_data, int)
 
         #store some things for later call to predict_ptr()
 
@@ -865,11 +812,6 @@ class ElasticNetH2O(object):
         whether row 'r' or column 'c' major order.
         """
 
-        assert_is_type(valid_xptr, c_void_p)
-        assert_is_type(valid_yptr, c_void_p, None)
-        assert_is_type(free_input_data, int)
-        assert_is_type(order, int, None)
-
         #assume self.ord already set by fit_ptr() at least
         #override self if chose to pass this option
         oldstorefullpath = self.store_full_path
@@ -936,14 +878,6 @@ class ElasticNetH2O(object):
         :param order: Order of data.  Default is None, and internally determined
             whether row 'r' or column 'c' major order.
         """
-
-        assert_is_type(train_x, numpy_ndarray, pandas_dataframe, None)
-        assert_is_type(train_y, numpy_ndarray, pandas_dataframe, None)
-        assert_is_type(valid_x, numpy_ndarray, pandas_dataframe, None)
-        assert_is_type(valid_y, numpy_ndarray, pandas_dataframe, None)
-        assert_is_type(sample_weight, numpy_ndarray, pandas_dataframe, None)
-        assert_is_type(free_input_data, int)
-        assert_is_type(order, int, None)
 
         #let fit() check and convert(to numpy)
         #train_x, train_y, valid_x, valid_y, weight
@@ -1015,19 +949,6 @@ class ElasticNetH2O(object):
 
         """
 
-        assert_is_type(source_dev, int, None)
-        assert_is_type(m_train, int, None)
-        assert_is_type(n, int, None)
-        assert_is_type(m_valid, int, None)
-        assert_is_type(double_precision, float, None)
-        assert_is_type(order, int, None)
-        assert_is_type(a, c_void_p, None)
-        assert_is_type(b, c_void_p, None)
-        assert_is_type(c, c_void_p, None)
-        assert_is_type(d, c_void_p, None)
-        assert_is_type(e, c_void_p, None)
-        assert_is_type(free_input_data, int, None)
-
         do_predict = 0  # only fit at first
 
         self._fitorpredict_ptr(
@@ -1074,12 +995,6 @@ class ElasticNetH2O(object):
         :param int free_input_data : Indicate if input data should be freed at
             the end of fit(). Default is 1.
         """
-        assert_is_type(train_x, numpy_ndarray, pandas_dataframe)
-        assert_is_type(train_y, numpy_ndarray, pandas_dataframe)
-        assert_is_type(valid_x, numpy_ndarray, pandas_dataframe, None)
-        assert_is_type(valid_y, numpy_ndarray, pandas_dataframe, None)
-        assert_is_type(sample_weight, numpy_ndarray, pandas_dataframe, None)
-        assert_is_type(free_input_data, int)
 
         return self.fit_predict(self, train_x, train_y, valid_x, valid_y,
                                 sample_weight, free_input_data)
@@ -1117,7 +1032,6 @@ class ElasticNetH2O(object):
 
     @gpu_id.setter
     def gpu_id(self, value):
-        assert_is_type(value, int)
         assert value >= 0, "GPU ID must be non-negative."
         self._gpu_id = value
 
@@ -1413,7 +1327,6 @@ class ElasticNet(object):
         _backend = os.environ.get('H2O4GPU_BACKEND', None)
         if _backend is not None:
             backend = _backend
-        assert_is_type(backend, str)
 
         # Fall back to Sklearn
         # Can remove if fully implement sklearn functionality

--- a/src/interface_py/h2o4gpu/solvers/kmeans.py
+++ b/src/interface_py/h2o4gpu/solvers/kmeans.py
@@ -129,6 +129,7 @@ class KMeansH2O(object):
         >>> kmeans.cluster_centers_
     """
 
+    # pylint: disable=unused-argument
     def __init__(
             self,
             # sklearn API (but with possibly different choices for defaults)

--- a/src/interface_py/h2o4gpu/solvers/kmeans.py
+++ b/src/interface_py/h2o4gpu/solvers/kmeans.py
@@ -14,7 +14,7 @@ import numpy as np
 from ..solvers.utils import _check_data_content, \
     _get_data, _setter
 from ..util.gpu import device_count
-from ..typecheck.typechecks import assert_is_type, assert_satisfies
+from ..typecheck.typechecks import assert_satisfies
 from ..types import cptr
 
 
@@ -148,24 +148,6 @@ class KMeansH2O(object):
             n_gpus=-1,
             init_data='randomselect',
             do_checks=1):
-
-        assert_is_type(n_clusters, int, type(np.int32), type(np.int64))
-        assert_is_type(init, str, np.ndarray)
-        assert_is_type(n_init, int, type(np.int32), type(np.int64))
-        assert_is_type(max_iter, int, type(np.int32), type(np.int64))
-        assert_is_type(tol, float,
-                       type(np.float16), type(np.float32), type(np.float64))
-        assert_is_type(precompute_distances, str, bool)
-        assert_is_type(verbose, int, type(np.int32), type(np.int64))
-        assert_is_type(random_state, int, None, type(np.int32), type(np.int64))
-        assert_is_type(copy_x, bool)
-        assert_is_type(n_jobs, int, type(np.int32), type(np.int64))
-        assert_is_type(algorithm, str)
-
-        assert_is_type(gpu_id, int, type(np.int32), type(np.int64))
-        assert_is_type(n_gpus, int, type(np.int32), type(np.int64))
-        assert_is_type(init_data, str)
-        assert_is_type(do_checks, int, type(np.int32), type(np.int64))
 
         # fix-up tol in case input was numpy
         example = np.fabs(1.0)
@@ -636,7 +618,6 @@ class KMeansH2O(object):
 
     @n_clusters.setter
     def n_clusters(self, value):
-        assert_is_type(value, int)
         assert_satisfies(value, value > 0,
                          "Number of clusters must be positive.")
         self._n_clusters = value
@@ -647,7 +628,6 @@ class KMeansH2O(object):
 
     @gpu_id.setter
     def gpu_id(self, value):
-        assert_is_type(value, int)
         assert_satisfies(value, value >= 0, "GPU ID must be non-negative.")
         self._gpu_id = value
 
@@ -657,7 +637,6 @@ class KMeansH2O(object):
 
     @max_iter.setter
     def max_iter(self, value):
-        assert_is_type(value, int)
         assert_satisfies(value, value > 0,
                          "Number of maximum iterations must be non-negative.")
         self._max_iter = value
@@ -704,7 +683,6 @@ class KMeans(object):
         _backend = os.environ.get('H2O4GPU_BACKEND', None)
         if _backend is not None:
             backend = _backend
-        assert_is_type(backend, str)
 
         # FIXME: Add init as array and kmeans++ to h2o4gpu
         # setup backup to sklearn class

--- a/src/interface_py/h2o4gpu/solvers/lasso.py
+++ b/src/interface_py/h2o4gpu/solvers/lasso.py
@@ -7,9 +7,6 @@
 from h2o4gpu.solvers import elastic_net
 from h2o4gpu.linear_model import coordinate_descent as sk
 from ..solvers.utils import _setter
-from ..typecheck.typechecks import (assert_is_type, numpy_ndarray,
-                                    pandas_dataframe)
-
 
 class Lasso(object):
     """H2O Lasso Regression Solver
@@ -49,7 +46,6 @@ class Lasso(object):
         _backend = os.environ.get('H2O4GPU_BACKEND', None)
         if _backend is not None:
             backend = _backend
-        assert_is_type(backend, str)
 
         # Fall back to Sklearn
         # Can remove if fully implement sklearn functionality

--- a/src/interface_py/h2o4gpu/solvers/linear_regression.py
+++ b/src/interface_py/h2o4gpu/solvers/linear_regression.py
@@ -7,9 +7,6 @@
 from h2o4gpu.solvers import elastic_net
 from h2o4gpu.linear_model import base as sk
 from ..solvers.utils import _setter
-from ..typecheck.typechecks import (assert_is_type, numpy_ndarray,
-                                    pandas_dataframe)
-
 
 class LinearRegression(object):
     """H2O LinearRegression Regression Solver
@@ -44,7 +41,6 @@ class LinearRegression(object):
         _backend = os.environ.get('H2O4GPU_BACKEND', None)
         if _backend is not None:
             backend = _backend
-        assert_is_type(backend, str)
 
         if backend == 'auto':
             # Fall back to Sklearn

--- a/src/interface_py/h2o4gpu/solvers/logistic.py
+++ b/src/interface_py/h2o4gpu/solvers/logistic.py
@@ -8,7 +8,6 @@ import numpy as np
 from h2o4gpu.solvers import elastic_net
 from h2o4gpu.linear_model import logistic as sk
 from ..solvers.utils import _setter
-from ..typecheck.typechecks import assert_is_type, assert_satisfies
 
 
 class LogisticRegression(object):
@@ -49,7 +48,6 @@ class LogisticRegression(object):
         _backend = os.environ.get('H2O4GPU_BACKEND', None)
         if _backend is not None:
             backend = _backend
-        assert_is_type(backend, str)
 
         # Fall back to Sklearn
         # Can remove if fully implement sklearn functionality

--- a/src/interface_py/h2o4gpu/solvers/ridge.py
+++ b/src/interface_py/h2o4gpu/solvers/ridge.py
@@ -7,7 +7,6 @@
 from h2o4gpu.solvers import elastic_net
 from h2o4gpu.linear_model import ridge as sk
 from ..solvers.utils import _setter
-from ..typecheck.typechecks import assert_is_type, assert_satisfies
 
 
 class Ridge(object):
@@ -45,7 +44,6 @@ class Ridge(object):
         _backend = os.environ.get('H2O4GPU_BACKEND', None)
         if _backend is not None:
             backend = _backend
-        assert_is_type(backend, str)
 
         # Fall back to Sklearn
         # Can remove if fully implement sklearn functionality

--- a/src/interface_py/h2o4gpu/solvers/truncated_svd.py
+++ b/src/interface_py/h2o4gpu/solvers/truncated_svd.py
@@ -7,7 +7,6 @@ import ctypes
 import numpy as np
 from ..libs.lib_tsvd import parameters
 from ..solvers.utils import _setter
-from ..typecheck.typechecks import assert_is_type
 
 
 class TruncatedSVDH2O(object):
@@ -246,7 +245,6 @@ class TruncatedSVD(object):
         _backend = os.environ.get('H2O4GPU_BACKEND', None)
         if _backend is not None:
             backend = _backend
-        assert_is_type(backend, str)
 
         # Fall back to Sklearn
         # Can remove if fully implement sklearn functionality

--- a/src/interface_py/h2o4gpu/solvers/xgboost.py
+++ b/src/interface_py/h2o4gpu/solvers/xgboost.py
@@ -51,8 +51,6 @@ class RandomForestClassifier(object):
         _backend = os.environ.get('H2O4GPU_BACKEND', None)
         if _backend is not None:
             backend = _backend
-        from ..typecheck.typechecks import assert_is_type
-        assert_is_type(backend, str)
 
         # Fall back to Sklearn
         # Can remove if fully implement sklearn functionality
@@ -254,8 +252,6 @@ class RandomForestRegressor(object):
         _backend = os.environ.get('H2O4GPU_BACKEND', None)
         if _backend is not None:
             backend = _backend
-        from ..typecheck.typechecks import assert_is_type
-        assert_is_type(backend, str)
 
         # Fall back to Sklearn
         # Can remove if fully implement sklearn functionality
@@ -437,8 +433,6 @@ class GradientBoostingClassifier(object):
         _backend = os.environ.get('H2O4GPU_BACKEND', None)
         if _backend is not None:
             backend = _backend
-        from ..typecheck.typechecks import assert_is_type
-        assert_is_type(backend, str)
 
         # Fall back to Sklearn
         # Can remove if fully implement sklearn functionality
@@ -653,8 +647,6 @@ class GradientBoostingRegressor(object):
         _backend = os.environ.get('H2O4GPU_BACKEND', None)
         if _backend is not None:
             backend = _backend
-        from ..typecheck.typechecks import assert_is_type
-        assert_is_type(backend, str)
 
         # Fall back to Sklearn
         # Can remove if fully implement sklearn functionality


### PR DESCRIPTION
Removes the type checks for now as they are very limiting, i.e. they fail in many places where `np.int` because we check for python `int` or python `int`, `np.int32` and `np.int64` only.

The type checker framework needs a bit more improvements and we can put them back in.