### PR TITLE
Error handling in docker scripts

### DIFF
--- a/scripts/make-docker-devel.sh
+++ b/scripts/make-docker-devel.sh
@@ -1,4 +1,6 @@
 #!/bin/bash
+set -e
+
 echo "Docker devel - BEGIN"
 nvidia-docker build  -t opsh2oai/h2o4gpu-buildversion${extratag}-build -f Dockerfile-build --rm=false --build-arg cuda=${dockerimage} .
 #-u `id -u`:`id -g`  -w `pwd` -v `pwd`:`pwd`:rw

--- a/scripts/make-docker-runtests.sh
+++ b/scripts/make-docker-runtests.sh
@@ -1,5 +1,6 @@
 #!/bin/bash
 # Requires one has already done(e.g.): make docker-build-nccl-cuda9 to get wheel built or wheel was unstashed on jenkins
+set -e
 
 echo "Docker devel test and pylint - BEGIN"
 nvidia-docker build  -t opsh2oai/h2o4gpu-buildversion${extratag}-build -f Dockerfile-build --rm=false --build-arg cuda=${dockerimage} .

--- a/scripts/make-docker-runtime.sh
+++ b/scripts/make-docker-runtime.sh
@@ -1,4 +1,5 @@
 #!/bin/bash
+set -e
 echo "Docker runtime - BEGIN"
 
 echo "Docker runtime - Build"

--- a/tests_open/test_kmeans.py
+++ b/tests_open/test_kmeans.py
@@ -167,3 +167,4 @@ class TestKmeans(object):
         end_sk = time.time()
 
         assert end_h2o - start_h2o <= end_sk - start_sk
+        assert False  # TODO remove - only to test `set -e` in scripts

--- a/tests_open/test_kmeans.py
+++ b/tests_open/test_kmeans.py
@@ -167,4 +167,3 @@ class TestKmeans(object):
         end_sk = time.time()
 
         assert end_h2o - start_h2o <= end_sk - start_sk
-        assert False  # TODO remove - only to test `set -e` in scripts


### PR DESCRIPTION
Errors should be propagated up so the build/user knows what's going on.

Initial build should fail intentionally (just as a test).