### PR TITLE
Fix printf in kmeans

### DIFF
--- a/src/gpu/kmeans/kmeans_labels.h
+++ b/src/gpu/kmeans/kmeans_labels.h
@@ -261,8 +261,8 @@ namespace kmeans {
       );
 
       log_verbose(verbose,
-                  "Batch calculate distance - Free memory %ld | Required memory %ld | Runs %d",
-                  free_byte, required_byte, runs + 1
+                  "Batch calculate distance - Free memory %zu | Required memory %lf | Runs %d",
+                  free_byte, required_byte, runs
       );
 
       int offset = 0;


### PR DESCRIPTION
@pseudotensor does this look correct?

Noticed I also should probably just print `runs` instead of `runs+1` as `runs` is calculated using `std::ceil`.