### PR TITLE
Batched pairwise distances fixes #311

### DIFF
--- a/Dockerfile-build
+++ b/Dockerfile-build
@@ -58,7 +58,6 @@ RUN \
 
 COPY requirements_buildonly.txt requirements_buildonly.txt
 COPY requirements_runtime.txt requirements_runtime.txt
-COPY requirements_h2o.txt requirements_h2o.txt
 RUN \
     chmod a+rwx / && \
     chmod -R a+rwx /root  && \
@@ -67,6 +66,5 @@ RUN \
     eval "$(/root/.pyenv/bin/pyenv init -)" && \
     /root/.pyenv/bin/pyenv global 3.6.1 && \
     pip install setuptools && \
-    cat requirements_h2o.txt | xargs -n 1 -L 1 pip install && \
-    cat requirements_buildonly.txt | xargs -n 1 -L 1 pip install && \
-    cat requirements_runtime.txt | xargs -n 1 -L 1 pip install
+    pip install -r requirements_buildonly.txt && \
+    pip install -r requirements_runtime.txt

--- a/Dockerfile-runtime
+++ b/Dockerfile-runtime
@@ -65,7 +65,7 @@ COPY requirements_runtime.txt requirements.txt
 RUN \
   . h2o4gpu_env/bin/activate && \
   chmod a+rwx requirements*.txt && \
-  cat requirements.txt | xargs -n 1 -L 1 pip install --no-cache-dir
+  pip install --no-cache-dir -r requirements.txt
 
 # Add a canned jupyter notebook demo to the container
 RUN \

--- a/Makefile
+++ b/Makefile
@@ -405,7 +405,6 @@ apply_xgboost-nonccl-cuda9:  pipxgboost-nonccl-cuda9
 pipxgboost:
 	@echo "----- pip install xgboost built locally -----"
 	cd xgboost/python-package/dist && pip install xgboost-0.6-py3-none-any.whl --upgrade --target ../
-	cd xgboost/python-package/xgboost ; cp -a ../lib/libxgboost*.so .
 
 pipxgboost-nccl-cuda8:
 	@echo "----- pip install xgboost-nccl-cuda8 from S3 -----"

--- a/examples/py/demos/H2O4GPU_KMeans_Homesite.ipynb
+++ b/examples/py/demos/H2O4GPU_KMeans_Homesite.ipynb
@@ -96,6 +96,13 @@
    ]
   },
   {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## H2O4GPU K-Means (single-GPU)"
+   ]
+  },
+  {
    "cell_type": "code",
    "execution_count": null,
    "metadata": {
@@ -103,20 +110,12 @@
    },
    "outputs": [],
    "source": [
-    "# Prepare random starting labels\n",
-    "rows=np.shape(trainencflt)[0]\n",
-    "print(rows)\n",
-    "np.random.seed(1234)\n",
-    "import random\n",
-    "import numpy as np\n",
-    "labels=np.asarray([])\n",
-    "num=int(rows/k)\n",
-    "for x in range(0, num+1):\n",
-    "    if x<num:\n",
-    "        many=k\n",
-    "    else:\n",
-    "        many=rows%k\n",
-    "    labels = np.append(labels,np.asarray(random.sample(range(k), many)))"
+    "# Fit an H2O4GPU KMeans model with 1 GPU. 300 iterations by default.\n",
+    "model = h2o4gpu.KMeans(n_gpus=1, n_clusters=k)\n",
+    "%time model.fit(trainencflt)\n",
+    "\n",
+    "#%time train_centroid_distance = model.transform(trainencflt)\n",
+    "#%time train_labels     = model.predict(trainencflt)"
    ]
   },
   {
@@ -134,32 +133,9 @@
    },
    "outputs": [],
    "source": [
-    "# Fit an H2O4GPU KMeans model with 1 GPU. 1000 iterations by default.\n",
-    "model = h2o4gpu.KMeans(n_gpus=1, n_clusters=k)\n",
-    "%time model.fit(trainencflt, labels)\n",
-    "\n",
-    "#%time train_centroid_distance = model.transform(trainencflt)\n",
-    "#%time train_labels     = model.predict(trainencflt)"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "## H2O4GPU K-Means (multi-GPU with restrictions)"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {
-    "collapsed": true
-   },
-   "outputs": [],
-   "source": [
-    "# Fit an H2O4GPU KMeans model with 2 GPUs. 1000 iterations by default.\n",
+    "# Fit an H2O4GPU KMeans model with 2 GPUs. 300 iterations by default.\n",
     "model = h2o4gpu.KMeans(n_gpus=2, n_clusters=k)\n",
-    "%time model.fit(trainencflt, labels)\n",
+    "%time model.fit(trainencflt)\n",
     "\n",
     "#%time train_centroid_distance = model.transform(trainencflt)\n",
     "#%time train_labels     = model.predict(trainencflt)"
@@ -183,7 +159,7 @@
    "source": [
     "# Fit a SciKit Learn KMeans model with all available cores.\n",
     "from sklearn.cluster import KMeans\n",
-    "model = KMeans(algorithm='full',n_clusters=k, init='random', n_init=1, n_jobs=-1, max_iter=10, tol=1e-8,verbose=1)\n",
+    "model = KMeans(n_clusters=k, n_init=1, n_jobs=-1)\n",
     "%time model.fit(trainencflt)\n",
     "#train_assignments = model.predict(trainencflt)\n",
     "#test_assignments = model.predict(testencflt)"
@@ -193,9 +169,9 @@
  "metadata": {
   "anaconda-cloud": {},
   "kernelspec": {
-   "display_name": "env",
+   "display_name": ".venv",
    "language": "python",
-   "name": "env"
+   "name": ".venv"
   },
   "language_info": {
    "codemirror_mode": {

--- a/examples/py/demos/H2O4GPU_KMeans_Images.ipynb
+++ b/examples/py/demos/H2O4GPU_KMeans_Images.ipynb
@@ -168,10 +168,8 @@
     "\n",
     "rows=np.shape(dataset)[0]\n",
     "print(\"rows=%d\" % (rows))\n",
-    "labels = np.random.randint(rows, size=rows) % k\n",
     "\n",
-    "dataset = dataset.astype(float32)\n",
-    "labels = labels.astype(float32)"
+    "dataset = dataset.astype(float32)"
    ]
   },
   {
@@ -191,11 +189,11 @@
     }
    ],
    "source": [
-    "# Fit an H2O4GPU KMeans model for 21 clusters on a single GPU with 1000 iterations.\n",
+    "# Fit an H2O4GPU KMeans model for 21 clusters with 300 iterations on all available GPUs.\n",
     "import h2o4gpu\n",
     "\n",
     "model = h2o4gpu.KMeans(n_clusters=k, tol=1e-7)\n",
-    "%time model.fit(dataset, labels)\n",
+    "%time model.fit(dataset)\n",
     "asses = model.predict(dataset)\n",
     "cents = model.cluster_centers_"
    ]

--- a/requirements_buildonly.txt
+++ b/requirements_buildonly.txt
@@ -5,7 +5,7 @@ pytest-xdist>=1.18.0
 sphinx>=1.5.6
 sphinx_rtd_theme>=0.2.4
 wheel>=0.29.0
-h2o<3.16.0.1
+h2o<3.16.0.0
 coverage>=4.4.1
 cmake>=0.8.0
 Cython>=0.25.2

--- a/requirements_buildonly.txt
+++ b/requirements_buildonly.txt
@@ -5,7 +5,7 @@ pytest-xdist>=1.18.0
 sphinx>=1.5.6
 sphinx_rtd_theme>=0.2.4
 wheel>=0.29.0
-h2o>=3.10.4.8
+h2o==3.10.4.8
 coverage>=4.4.1
 cmake>=0.8.0
 Cython>=0.25.2

--- a/requirements_buildonly.txt
+++ b/requirements_buildonly.txt
@@ -5,7 +5,7 @@ pytest-xdist>=1.18.0
 sphinx>=1.5.6
 sphinx_rtd_theme>=0.2.4
 wheel>=0.29.0
-h2o==3.10.4.8
+h2o<3.16.0.1
 coverage>=4.4.1
 cmake>=0.8.0
 Cython>=0.25.2

--- a/requirements_h2o.txt
+++ b/requirements_h2o.txt
@@ -1,8 +1,0 @@
-requests
-tabulate
-future
-colorama>=0.3.8
-chardet<3.1.0,>=3.0.2
-idna<2.7,>=2.5
-urllib3<1.23,>=1.21.1
-certifi>=2017.4.17

--- a/src/gpu/kmeans/kmeans_centroids.h
+++ b/src/gpu/kmeans/kmeans_centroids.h
@@ -143,7 +143,7 @@ void find_centroids(int q, int n, int d, int k,
                       labels.end(),
                       indices.begin());
   // TODO cub is faster but sort_by_key_int isn't sorting, possibly a bug
-  //  mycub::sort_by_key_int(labels, indices);
+//    mycub::sort_by_key_int(labels, indices);
 
 #if(CHECK)
   gpuErrchk(cudaGetLastError());
@@ -196,7 +196,6 @@ void find_centroids(int q, int n, int d, int k,
             thrust::raw_pointer_cast(centroids.data()));
 #if(CHECK)
     gpuErrchk(cudaGetLastError());
-    gpuErrchk(cudaDeviceSynchronize());
 #endif
   }
 }

--- a/src/gpu/kmeans/kmeans_h2o4gpu.cu
+++ b/src/gpu/kmeans/kmeans_h2o4gpu.cu
@@ -424,9 +424,9 @@ thrust::host_vector<T> kmeans_parallel(int verbose, int seed, const char ord,
       for(int run = 0; run < runs; run++) {
         if( run + 1 == runs ) {
           rows_per_run = rows_per_gpu % rows_per_run;
-          pairwise_distances.resize(rows_per_run * potential_k_rows, (T)0.0);
+          d_all_costs.resize(rows_per_run * potential_k_rows, (T)0.0);
         } else {
-            thrust::fill_n(pairwise_distances.begin(), pairwise_distances.size(), (T)0.0);
+            thrust::fill_n(d_all_costs.begin(), d_all_costs.size(), (T)0.0);
         }
 
         kmeans::detail::calculate_distances(verbose, 0, rows_per_run, cols, potential_k_rows,

--- a/src/gpu/kmeans/kmeans_h2o4gpu.cu
+++ b/src/gpu/kmeans/kmeans_h2o4gpu.cu
@@ -424,10 +424,9 @@ thrust::host_vector<T> kmeans_parallel(int verbose, int seed, const char ord,
       for(int run = 0; run < runs; run++) {
         if( run + 1 == runs ) {
           rows_per_run = rows_per_gpu % rows_per_run;
-          d_all_costs.resize(rows_per_run * potential_k_rows, (T)0.0);
-        } else {
-            thrust::fill_n(d_all_costs.begin(), d_all_costs.size(), (T)0.0);
         }
+
+        thrust::fill_n(d_all_costs.begin(), d_all_costs.size(), (T)0.0);
 
         kmeans::detail::calculate_distances(verbose, 0, rows_per_run, cols, potential_k_rows,
                                             *data[i], offset,

--- a/src/gpu/kmeans/kmeans_h2o4gpu.cu
+++ b/src/gpu/kmeans/kmeans_h2o4gpu.cu
@@ -422,7 +422,7 @@ thrust::host_vector<T> kmeans_parallel(int verbose, int seed, const char ord,
       size_t rows_per_run = rows_per_gpu / runs;
       thrust::device_vector<T> d_all_costs(rows_per_run * potential_k_rows);
       for(int run = 0; run < runs; run++) {
-        if( run + 1 == runs ) {
+        if( run + 1 == runs && rows_per_gpu % rows_per_run != 0) {
           rows_per_run = rows_per_gpu % rows_per_run;
         }
 

--- a/src/gpu/kmeans/kmeans_h2o4gpu.h
+++ b/src/gpu/kmeans/kmeans_h2o4gpu.h
@@ -55,11 +55,11 @@ void count_pts_per_centroid(
 
     size_t runs = std::ceil( required_byte / (double)free_byte );
     size_t offset = 0;
-    size_t rows_per_run = n / rows;
+    size_t rows_per_run = rows_per_gpu / runs;
     thrust::device_vector<T> pairwise_distances(rows_per_run * k);
     for(int run = 0; run < runs; run++) {
       if( run + 1 == runs ) {
-        rows_per_run = n % rows_per_run;
+        rows_per_run = rows_per_gpu % rows_per_run;
         pairwise_distances.resize(rows_per_run * k, (T)0.0);
       } else {
         thrust::fill_n(pairwise_distances.begin(), pairwise_distances.size(), (T)0.0);

--- a/src/gpu/kmeans/kmeans_h2o4gpu.h
+++ b/src/gpu/kmeans/kmeans_h2o4gpu.h
@@ -60,10 +60,9 @@ void count_pts_per_centroid(
     for(int run = 0; run < runs; run++) {
       if( run + 1 == runs ) {
         rows_per_run = rows_per_gpu % rows_per_run;
-        pairwise_distances.resize(rows_per_run * k, (T)0.0);
-      } else {
-        thrust::fill_n(pairwise_distances.begin(), pairwise_distances.size(), (T)0.0);
       }
+
+      thrust::fill_n(pairwise_distances.begin(), pairwise_distances.size(), (T)0.0);
 
       kmeans::detail::calculate_distances(verbose, 0, rows_per_run, cols, k,
                                           *data[i], offset,

--- a/src/gpu/kmeans/kmeans_h2o4gpu.h
+++ b/src/gpu/kmeans/kmeans_h2o4gpu.h
@@ -64,6 +64,7 @@ void count_pts_per_centroid(
     thrust::host_vector<T> &weights
 ) {
   int k = centroids.size() / cols;
+  #pragma omp parallel for
   for (int i = 0; i < num_gpu; i++) {
     thrust::host_vector<int> weights_tmp(weights.size());
 
@@ -84,8 +85,6 @@ void count_pts_per_centroid(
                                                 );
                                               }
     );
-
-    CUDACHECK(cudaDeviceSynchronize());
 
     kmeans::detail::memcpy(weights_tmp, counts);
     kmeans::detail::streamsync(i);

--- a/src/gpu/kmeans/kmeans_h2o4gpu.h
+++ b/src/gpu/kmeans/kmeans_h2o4gpu.h
@@ -58,7 +58,7 @@ void count_pts_per_centroid(
     size_t rows_per_run = rows_per_gpu / runs;
     thrust::device_vector<T> pairwise_distances(rows_per_run * k);
     for(int run = 0; run < runs; run++) {
-      if( run + 1 == runs ) {
+      if( run + 1 == runs && rows_per_gpu % rows_per_run != 0) {
         rows_per_run = rows_per_gpu % rows_per_run;
       }
 

--- a/src/gpu/kmeans/kmeans_impl.h
+++ b/src/gpu/kmeans/kmeans_impl.h
@@ -120,7 +120,7 @@ int kmeans(
 
       detail::batch_calculate_distances(verbose, q, n / n_gpu, d, k,
                                         *data[q], *centroids[q], *data_dots[q], *centroid_dots[q],
-                                        [&](int n, int offset, thrust::device_vector<T> &pairwise_distances) {
+                                        [&](int n, size_t offset, thrust::device_vector<T> &pairwise_distances) {
                                           detail::relabel(n, k, pairwise_distances, *labels[q], offset);
                                         }
       );
@@ -229,7 +229,7 @@ int kmeans(
 
     detail::batch_calculate_distances(verbose, q, n / n_gpu, d, k,
                                       *data[q], *centroids[q], *data_dots[q], *centroid_dots[q],
-                                      [=](int n, int offset, thrust::device_vector<T> &pairwise_distances) {
+                                      [=](int n, size_t offset, thrust::device_vector<T> &pairwise_distances) {
                                         detail::relabel(n, k, pairwise_distances, *labels[q], offset);
                                       }
     );

--- a/src/gpu/kmeans/kmeans_impl.h
+++ b/src/gpu/kmeans/kmeans_impl.h
@@ -111,19 +111,18 @@ int kmeans(
 
     if (*flag) continue;
 
+    safe_cuda(cudaSetDevice(dList[0]));
+    d_old_centroids = *centroids[dList[0]];
+
+    #pragma omp parallel for
     for (int q = 0; q < n_gpu; q++) {
       safe_cuda(cudaSetDevice(dList[q]));
-
-      if (0 == q) {
-        d_old_centroids = *centroids[q];
-      }
 
       detail::batch_calculate_distances(verbose, q, n / n_gpu, d, k,
                                         *data[q], *centroids[q], *data_dots[q], *centroid_dots[q],
                                         [&](int n, size_t offset, thrust::device_vector<T> &pairwise_distances) {
                                           detail::relabel(n, k, pairwise_distances, *labels[q], offset);
-                                        }
-      );
+                                        });
 
       log_verbose(verbose, "KMeans - Relabeled.");
 

--- a/src/gpu/kmeans/kmeans_labels.cu
+++ b/src/gpu/kmeans/kmeans_labels.cu
@@ -142,7 +142,7 @@ void calculate_distances<double>(int verbose, int q, size_t n, int d, int k,
 
   if (k <= 16 && d <= 64) {
     const int BLOCK_SIZE_MUL = 128;
-    int block_rows = std::min(BLOCK_SIZE_MUL / k, n);
+    int block_rows = std::min((size_t)BLOCK_SIZE_MUL / k, n);
     int grid_size = std::ceil(static_cast<double>(n) / block_rows);
 
     int shared_size_B = d * k * sizeof(double);
@@ -209,7 +209,7 @@ void calculate_distances<float>(int verbose, int q, size_t n, int d, int k,
 
   if (k <= 16 && d <= 64) {
     const int BLOCK_SIZE_MUL = 128;
-    int block_rows = std::min(BLOCK_SIZE_MUL / k, n);
+    int block_rows = std::min((size_t)BLOCK_SIZE_MUL / k, n);
     int grid_size = std::ceil(static_cast<float>(n) / block_rows);
 
     int shared_size_B = d * k * sizeof(float);

--- a/src/gpu/kmeans/kmeans_labels.cu
+++ b/src/gpu/kmeans/kmeans_labels.cu
@@ -118,9 +118,9 @@ __global__ void matmul(const float_t *A, const float_t *B, float_t *C,
 }
 
 template<>
-void calculate_distances<double>(int verbose, int q, int n, int d, int k,
+void calculate_distances<double>(int verbose, int q, size_t n, int d, int k,
                                  thrust::device_vector<double> &data,
-                                 int data_offset,
+                                 size_t data_offset,
                                  thrust::device_vector<double> &centroids,
                                  thrust::device_vector<double> &data_dots,
                                  thrust::device_vector<double> &centroid_dots,
@@ -185,9 +185,9 @@ void calculate_distances<double>(int verbose, int q, int n, int d, int k,
 }
 
 template<>
-void calculate_distances<float>(int verbose, int q, int n, int d, int k,
+void calculate_distances<float>(int verbose, int q, size_t n, int d, int k,
                                 thrust::device_vector<float> &data,
-                                int data_offset,
+                                size_t data_offset,
                                 thrust::device_vector<float> &centroids,
                                 thrust::device_vector<float> &data_dots,
                                 thrust::device_vector<float> &centroid_dots,

--- a/src/gpu/kmeans/kmeans_labels.cu
+++ b/src/gpu/kmeans/kmeans_labels.cu
@@ -154,8 +154,6 @@ void calculate_distances<double>(int verbose, int q, size_t n, int d, int k,
             thrust::raw_pointer_cast(pairwise_distances.data()),
             alpha, beta, n, d, k, block_rows
     );
-
-    safe_cuda(cudaDeviceSynchronize());
   } else {
     cublasStatus_t stat = safe_cublas(cublasDgemm(detail::cublas_handle[dev_num],
                                                   CUBLAS_OP_T, CUBLAS_OP_N,
@@ -180,7 +178,6 @@ void calculate_distances<double>(int verbose, int q, size_t n, int d, int k,
 
   #if(CHECK)
   gpuErrchk(cudaGetLastError());
-  gpuErrchk(cudaDeviceSynchronize());
   #endif
 }
 
@@ -221,7 +218,6 @@ void calculate_distances<float>(int verbose, int q, size_t n, int d, int k,
             thrust::raw_pointer_cast(pairwise_distances.data()),
             alpha, beta, n, d, k, block_rows
     );
-    safe_cuda(cudaDeviceSynchronize());
   } else {
     cublasStatus_t stat = safe_cublas(cublasSgemm(detail::cublas_handle[dev_num],
                                                   CUBLAS_OP_T, CUBLAS_OP_N,
@@ -246,7 +242,6 @@ void calculate_distances<float>(int verbose, int q, size_t n, int d, int k,
 
   #if(CHECK)
   gpuErrchk(cudaGetLastError());
-  gpuErrchk(cudaDeviceSynchronize());
   #endif
 }
 

--- a/src/gpu/kmeans/kmeans_labels.h
+++ b/src/gpu/kmeans/kmeans_labels.h
@@ -272,10 +272,9 @@ namespace kmeans {
       for(int run = 0; run < runs; run++) {
         if( run + 1 == runs ) {
           rows_per_run = n % rows_per_run;
-          pairwise_distances.resize(rows_per_run * k, (T)0.0);
-        } else {
-            thrust::fill_n(pairwise_distances.begin(), pairwise_distances.size(), (T)0.0);
         }
+
+        thrust::fill_n(pairwise_distances.begin(), pairwise_distances.size(), (T)0.0);
 
         log_verbose(verbose,
                     "Batch calculate distance - Allocated"

--- a/src/gpu/kmeans/kmeans_labels.h
+++ b/src/gpu/kmeans/kmeans_labels.h
@@ -172,7 +172,6 @@ namespace kmeans {
             thrust::raw_pointer_cast(dots.data()));
 #if(CHECK)
         gpuErrchk( cudaGetLastError() );
-        gpuErrchk( cudaDeviceSynchronize() );
 #endif
 
       }
@@ -224,7 +223,6 @@ namespace kmeans {
               thrust::raw_pointer_cast(dots.data()));
 #if(CHECK)
         gpuErrchk( cudaGetLastError() );
-        gpuErrchk( cudaDeviceSynchronize() );
 #endif
       };
 
@@ -359,7 +357,6 @@ namespace kmeans {
             thrust::raw_pointer_cast(labels.data() + offset));
 #if(CHECK)
         gpuErrchk( cudaGetLastError() );
-        gpuErrchk( cudaDeviceSynchronize() );
 #endif
       }
 

--- a/src/gpu/kmeans/kmeans_labels.h
+++ b/src/gpu/kmeans/kmeans_labels.h
@@ -270,7 +270,7 @@ namespace kmeans {
       size_t rows_per_run = n / runs;
       thrust::device_vector<T> pairwise_distances(rows_per_run * k);
       for(int run = 0; run < runs; run++) {
-        if( run + 1 == runs ) {
+        if( run + 1 == runs && n % rows_per_run != 0) {
           rows_per_run = n % rows_per_run;
         }
 


### PR DESCRIPTION
* Use size_t instead of int in multiple places to avoid overflows
* Allocate the pairwise distance vector only once
* Add retries in batched distance calculation - in case CUDA memory info is incorrect
* Use the batched method everywhere - no more code duplication. In some places it required `struct` functors for thrust b/c it seems we cannot compose `__device__` lambdas inside regular C/C++ lambdas.
* Use `omp` pragmas so multiGPU code can use in parallel instead of sequentially