### PR TITLE
Fixes #333 KMeans++ perf.

### DIFF
--- a/src/gpu/kmeans/kmeans_h2o4gpu.cu
+++ b/src/gpu/kmeans/kmeans_h2o4gpu.cu
@@ -239,7 +239,7 @@ template<typename T>
 void add_centroid(int idx, int cols,
                   thrust::host_vector<T> &data,
                   thrust::host_vector<T> &weights,
-                  thrust::host_vector<T> &centroids) {
+                  std::vector<T> &centroids) {
   for (int i = 0; i < cols; i++) {
     centroids.push_back(data[idx * cols + i]);
   }
@@ -266,19 +266,20 @@ void kmeans_plus_plus(
     int cols,
     thrust::host_vector<T> &centroids) {
 
+  std::vector<T> std_centroids(0);
+  std_centroids.reserve(k * cols);
+
   int centroid_idx = pick_point_idx_weighted(
       seed,
       (std::vector<T> *) NULL,
       weights
   );
 
-  add_centroid(centroid_idx, cols, data, weights, centroids);
+  add_centroid(centroid_idx, cols, data, weights, std_centroids);
 
-  log_verbose(verbose, "KMeans++ - Allocating memory %d | %d | %d", data.size(), cols, centroids.size());
 
   std::vector<T> best_pairwise_distances(data.size() / cols); // one for each row in data
   std::vector<T> std_data(data.begin(), data.end());
-  std::vector<T> std_centroids(centroids.begin(), centroids.end());
 
   compute_distances(std_data,
                     std_centroids,
@@ -297,7 +298,7 @@ void kmeans_plus_plus(
         weights
     );
 
-    add_centroid(centroid_idx, cols, data, weights, centroids);
+    add_centroid(centroid_idx, cols, data, weights, std_centroids);
 
     best_pairwise_distances[centroid_idx] = 0;
 
@@ -312,6 +313,8 @@ void kmeans_plus_plus(
 
     std::fill(curr_pairwise_distances.begin(), curr_pairwise_distances.end(), (T)0.0);
   }
+
+  centroids.assign(std_centroids.begin(), std_centroids.end());
 }
 
 template<typename T>

--- a/src/gpu/kmeans/kmeans_h2o4gpu.cu
+++ b/src/gpu/kmeans/kmeans_h2o4gpu.cu
@@ -243,10 +243,7 @@ void add_centroid(int idx, int cols,
   for (int i = 0; i < cols; i++) {
     centroids.push_back(data[idx * cols + i]);
   }
-  for (int i = cols - 1; i >= 0; i--) {
-    data.erase(data.begin() + idx * cols + i);
-  }
-  weights.erase(weights.begin() + idx);
+  weights[idx] = 0;
 }
 
 /**
@@ -288,6 +285,9 @@ void kmeans_plus_plus(
                     best_pairwise_distances,
                     data.size() / cols, cols, 1);
 
+  int centroids_nr = std_centroids.size() / cols;
+  std::vector<T> curr_pairwise_distances( centroids_nr * (std_data.size() / cols));
+
   for (int iter = 0; iter < k - 1; iter++) {
     log_verbose(verbose, "KMeans++ - Iteraton %d/%d.", iter, k-1);
 
@@ -299,14 +299,7 @@ void kmeans_plus_plus(
 
     add_centroid(centroid_idx, cols, data, weights, centroids);
 
-    best_pairwise_distances.erase(best_pairwise_distances.begin() + centroid_idx);
-
-    // TODO necessary?
-    std_data = std::vector<T>(data.begin(), data.end());
-    std_centroids = std::vector<T>(centroids.begin() + cols * (iter + 1), centroids.end());
-
-    int centroids_nr = std_centroids.size() / cols;
-    std::vector<T> curr_pairwise_distances( centroids_nr * (std_data.size() / cols));
+    best_pairwise_distances[centroid_idx] = 0;
 
     compute_distances(std_data,
                       std_centroids,
@@ -316,6 +309,8 @@ void kmeans_plus_plus(
     for (int i = 0; i < curr_pairwise_distances.size(); i++) {
       best_pairwise_distances[i] = std::min(curr_pairwise_distances[i], best_pairwise_distances[i]);
     }
+
+    std::fill(curr_pairwise_distances.begin(), curr_pairwise_distances.end(), (T)0.0);
   }
 }
 

--- a/src/gpu/kmeans/kmeans_h2o4gpu.cu
+++ b/src/gpu/kmeans/kmeans_h2o4gpu.cu
@@ -277,7 +277,6 @@ void kmeans_plus_plus(
 
   add_centroid(centroid_idx, cols, data, weights, std_centroids);
 
-
   std::vector<T> best_pairwise_distances(data.size() / cols); // one for each row in data
   std::vector<T> std_data(data.begin(), data.end());
 
@@ -286,8 +285,7 @@ void kmeans_plus_plus(
                     best_pairwise_distances,
                     data.size() / cols, cols, 1);
 
-  int centroids_nr = std_centroids.size() / cols;
-  std::vector<T> curr_pairwise_distances( centroids_nr * (std_data.size() / cols));
+  std::vector<T> curr_pairwise_distances( std_data.size() / cols);
 
   for (int iter = 0; iter < k - 1; iter++) {
     log_verbose(verbose, "KMeans++ - Iteraton %d/%d.", iter, k-1);
@@ -300,10 +298,14 @@ void kmeans_plus_plus(
 
     add_centroid(centroid_idx, cols, data, weights, std_centroids);
 
+    std::vector<T> most_recent_centroids;
+    most_recent_centroids.reserve(cols);
+    add_centroid(centroid_idx, cols, data, weights, most_recent_centroids);
+
     best_pairwise_distances[centroid_idx] = 0;
 
     compute_distances(std_data,
-                      std_centroids,
+                      most_recent_centroids,
                       curr_pairwise_distances,
                       std_data.size() / cols, cols, 1);
 


### PR DESCRIPTION
* Don't allocate new vectors at each iteration
* Don't erase from vectors (instead set weight to 0)

Haven't run on homesite yet but on a similarly sized dataset now I'm getting (before would run around 1m 15-30sec):

```
>>> n_samples = 260000
>>> centers = 1000
>>> X, true_labels = make_blobs(n_samples=n_samples, centers=centers, n_features=300)
>>> s = time.time()
>>> kmeans_h2o = KMeans(n_gpus=1, n_clusters=centers).fit(X)
>>> print(time.time() - s)
19.270898818969727
>>> v_measure_score(kmeans_h2o.labels_, true_labels)
0.98429668669984283
>>> s = time.time()
>>> kmeans_h2o2 = KMeans(n_gpus=1, init='random', n_clusters=centers).fit(X)
>>> print(time.time() - s)
10.995243072509766
>>> v_measure_score(kmeans_h2o2.labels_, true_labels)
0.9653079939768735
```

~~edit: for homesite it runs a lot more iterations than `init=random`, need to double check this change~~

Ran on homesite with `max_iter=1000, n_gpus=1` on my 1080 got `Wall time: 22.3 s`

#334 still present, though. For some values of `random_state` n_gpus=2 is actually slower than 1.