### PR TITLE
Fixes #362

### DIFF
--- a/src/gpu/kmeans/kmeans_general.h
+++ b/src/gpu/kmeans/kmeans_general.h
@@ -3,7 +3,10 @@
  * License   Apache License Version 2.0 (see LICENSE for details)
  */
 #pragma once
+#include <thrust/device_vector.h>
 #include "../../common/logger.h"
+#include <iostream>
+
 #define MAX_NGPUS 16
 
 #define VERBOSE 0
@@ -24,3 +27,14 @@
       exit(EXIT_FAILURE);                             \
     }                                                 \
   } while(0)
+
+template<typename T>
+void printVector(const char *msg, thrust::device_vector<T> dev_vec) {
+  thrust::host_vector<T> host_vec = dev_vec;
+  std::cout << "\n>>> " << msg << std::endl;
+  std::cout.precision(17);
+  for (int i = 0; i < host_vec.size(); ++i) {
+    std::cout << std::fixed << host_vec[i] << " ";
+  }
+  std::cout << std::endl;
+}

--- a/src/gpu/kmeans/kmeans_labels.cu
+++ b/src/gpu/kmeans/kmeans_labels.cu
@@ -176,9 +176,9 @@ void calculate_distances<double>(int verbose, int q, size_t n, int d, int k,
                    pairwise_distances.end(),
                    absolute_value<double>()); // in-place transformation to ensure all distances are positive indefinite
 
-  #if(CHECK)
+#if(CHECK)
   gpuErrchk(cudaGetLastError());
-  #endif
+#endif
 }
 
 template<>
@@ -207,7 +207,7 @@ void calculate_distances<float>(int verbose, int q, size_t n, int d, int k,
   if (k <= 16 && d <= 64) {
     const int BLOCK_SIZE_MUL = 128;
     int block_rows = std::min((size_t)BLOCK_SIZE_MUL / k, n);
-    int grid_size = std::ceil(static_cast<float>(n) / block_rows);
+    int grid_size = std::ceil(static_cast<double>(n) / block_rows);
 
     int shared_size_B = d * k * sizeof(float);
     int shared_size_A = block_rows * d * sizeof(float);
@@ -236,13 +236,19 @@ void calculate_distances<float>(int verbose, int q, size_t n, int d, int k,
     }
   }
 
+  // TODO necessary? add to doubles?
+  cudaDeviceSynchronize();
+
   thrust::for_each(pairwise_distances.begin(),
                    pairwise_distances.end(),
                    absolute_value<float>()); // in-place transformation to ensure all distances are positive indefinite
 
-  #if(CHECK)
+  // TODO necessary? add to doubles?
+  cudaDeviceSynchronize();
+
+#if(CHECK)
   gpuErrchk(cudaGetLastError());
-  #endif
+#endif
 }
 
 }


### PR DESCRIPTION
For certain datasets (i.e. Homesite) `atomiAdd(float*, float)` was *very* unstable.
This is due to the fact that, because of rounding errors, it is not a transitive operation
and we are computing new centroids using kernels which run in a parallel (indeterministic) fashion.

This fix uses Kahan summation, which works well but bumps the memory footprint and is here as a 'quick' fix. In the long term, we can change the centroids matrix to always be of type double.
This change will require a little bit more time, though.

Another thing to have in mind should we hardcode `centroids` to double is potential time perf hit - running Homesite using `double` is several times slower - bumping `centroids` to double might cause similar speed problems potentially?

EDIT: actually, instead of using Kahan, which seems to have some problems for multi-GPU, we can accumulate values here into `double`.