### PR TITLE
[Py] Fix issue with XGBoost regressors prediction

### DIFF
--- a/src/interface_py/h2o4gpu/solvers/xgboost.py
+++ b/src/interface_py/h2o4gpu/solvers/xgboost.py
@@ -358,8 +358,6 @@ class RandomForestRegressor(object):
             self.set_attributes()
             return res
         res = self.model.predict(X)
-        res[res < 0.5] = 0
-        res[res > 0.5] = 1
         self.set_attributes()
         return res.squeeze()
 
@@ -756,8 +754,6 @@ class GradientBoostingRegressor(object):
             self.set_attributes()
             return res
         res = self.model.predict(X)
-        res[res < 0.5] = 0
-        res[res > 0.5] = 1
         self.set_attributes()
         return res.squeeze()
 


### PR DESCRIPTION
This should only be done for classifiers but not regressors.