### PR TITLE
Add missing imports for tsvd and update default family for scikit fallback

### DIFF
--- a/src/interface_py/h2o4gpu/__init__.base.py
+++ b/src/interface_py/h2o4gpu/__init__.base.py
@@ -21,7 +21,9 @@ from .solvers.xgboost import GradientBoostingClassifier
 from .solvers.xgboost import GradientBoostingRegressor
 from .solvers.kmeans import KMeans
 from .solvers.pca import PCA
+from .solvers.pca import PCAH2O
 from .solvers.truncated_svd import TruncatedSVD
+from .solvers.truncated_svd import TruncatedSVDH2O
 from .typecheck import typechecks
 from .typecheck import compatibility
 from . import h2o4gpu_exceptions

--- a/src/interface_py/h2o4gpu/solvers/__init__.py
+++ b/src/interface_py/h2o4gpu/solvers/__init__.py
@@ -13,6 +13,7 @@ from ..solvers.lasso import Lasso
 from ..solvers.ridge import Ridge
 from ..solvers.kmeans import KMeans
 from ..solvers.pca import PCA
+from ..solvers.pca import PCAH2O
 from ..solvers.xgboost import RandomForestRegressor
 from ..solvers.xgboost import RandomForestClassifier
 from ..solvers.xgboost import GradientBoostingClassifier

--- a/src/interface_py/h2o4gpu/solvers/truncated_svd.py
+++ b/src/interface_py/h2o4gpu/solvers/truncated_svd.py
@@ -271,7 +271,8 @@ class TruncatedSVD(object):
         # Can remove if fully implement sklearn functionality
         self.do_sklearn = False
         if backend == 'auto':
-            params_string = ['algorithm', 'n_iter', 'random_state', 'tol', 'gpu_id']
+            params_string = ['algorithm', 'n_iter', 'random_state', 'tol',
+                             'gpu_id']
             params = [algorithm, n_iter, random_state, tol, gpu_id]
             params_default = ['cusolver', 5, None, 1E-5, 0]
 
@@ -302,8 +303,9 @@ class TruncatedSVD(object):
             n_iter=n_iter,
             random_state=random_state,
             tol=tol)
-        self.model_h2o4gpu = TruncatedSVDH2O(n_components=n_components, algorithm = algorithm,
-                                             tol = tol, gpu_id = gpu_id)
+        self.model_h2o4gpu = TruncatedSVDH2O(n_components=n_components,
+                                             algorithm=algorithm,
+                                             tol=tol, gpu_id=gpu_id)
 
         if self.do_sklearn:
             if self.model_sklearn.algorithm == "cusolver":

--- a/src/interface_py/h2o4gpu/solvers/truncated_svd.py
+++ b/src/interface_py/h2o4gpu/solvers/truncated_svd.py
@@ -248,17 +248,19 @@ class TruncatedSVD(object):
 
     def __init__(self,
                  n_components=2,
-                 algorithm="arpack",
+                 algorithm="cusolver",
                  n_iter=5,
                  random_state=None,
-                 tol=0.,
+                 tol=1E-5,
                  verbose=False,
-                 backend='auto'):
+                 backend='auto',
+                 gpu_id=0):
         self.algorithm = algorithm
         self.n_components = n_components
         self.n_iter = n_iter
         self.random_state = random_state
         self.tol = tol
+        self.gpu_id = gpu_id
 
         import os
         _backend = os.environ.get('H2O4GPU_BACKEND', None)
@@ -269,9 +271,9 @@ class TruncatedSVD(object):
         # Can remove if fully implement sklearn functionality
         self.do_sklearn = False
         if backend == 'auto':
-            params_string = ['algorithm', 'n_iter', 'random_state', 'tol']
-            params = [algorithm, n_iter, random_state, tol]
-            params_default = ['arpack', 5, None, 0.]
+            params_string = ['algorithm', 'n_iter', 'random_state', 'tol', 'gpu_id']
+            params = [algorithm, n_iter, random_state, tol, gpu_id]
+            params_default = ['cusolver', 5, None, 1E-5, 0]
 
             i = 0
             for param in params:
@@ -300,9 +302,13 @@ class TruncatedSVD(object):
             n_iter=n_iter,
             random_state=random_state,
             tol=tol)
-        self.model_h2o4gpu = TruncatedSVDH2O(n_components=n_components)
+        self.model_h2o4gpu = TruncatedSVDH2O(n_components=n_components, algorithm = algorithm,
+                                             tol = tol, gpu_id = gpu_id)
 
         if self.do_sklearn:
+            if self.model_sklearn.algorithm == "cusolver":
+                self.model_sklearn.algorithm = "arpack" #Default scikit
+                self.algorithm = "arpack" #Default scikit
             self.model = self.model_sklearn
         else:
             self.model = self.model_h2o4gpu

--- a/tests_open/test_tsvd_wrapper.py
+++ b/tests_open/test_tsvd_wrapper.py
@@ -8,7 +8,7 @@ print(sys.path)
 
 logging.basicConfig(level=logging.DEBUG)
 
-def func(m=5000, n=10, k=9):
+def func(m=5000, n=10, k=9, algorithm="cusolver"):
     np.random.seed(1234)
 
     X = np.random.rand(m, n)
@@ -22,7 +22,9 @@ def func(m=5000, n=10, k=9):
     print("\n")
     print("Sklearn run through h2o4gpu wrapper")
 
-    h2o4gpu_tsvd_sklearn_wrapper = TruncatedSVD(n_components=k, algorithm="arpack", random_state=42, verbose=True)
+    h2o4gpu_tsvd_sklearn_wrapper = TruncatedSVD(n_components=k, algorithm=algorithm, random_state=42, verbose=True)
+    if algorithm == "cusolver":
+        assert h2o4gpu_tsvd_sklearn_wrapper.algorithm == "arpack", "algorithm should be arpack for default scikit"
     h2o4gpu_tsvd_sklearn_wrapper.fit(X)
 
     print("h2o4gpu tsvd Singular Values")
@@ -52,3 +54,4 @@ def func(m=5000, n=10, k=9):
     assert np.allclose(h2o4gpu_tsvd_sklearn_wrapper.explained_variance_ratio_, sklearn_tsvd.explained_variance_ratio_)
 
 def test_tsvd_error_k2(): func(n=50, k=2)
+def test_tsvd_error_k2_cusolver(): func(n=50, k=2, algorithm="cusolver")


### PR DESCRIPTION
* Add missing imports to `__init__ ` files
* Add `gpu_id` to `TruncatedSVD` class (previously added to `TruncatedSVDH2O` class)
* Update test to account for default family `cusolver`, which switches to `arpack` if `do_sklearn` is set to `true` with algorithm set to `cusolver`.