### PR TITLE
Confusion matrices for ROC analysis

### DIFF
--- a/src/cpu/metrics/metrics.cpp
+++ b/src/cpu/metrics/metrics.cpp
@@ -7,7 +7,7 @@
 #include "metrics/metrics.h"
 
 namespace h2o4gpu {
-    
+
   template <typename T>
     std::vector<size_t> argsort(const std::vector<T> &v) {
     std::vector<size_t> idx(v.size());
@@ -16,8 +16,10 @@ namespace h2o4gpu {
     return idx;
   }
 
-  typedef double(*MetricFunc)(double, double, double, double);
-  
+  typedef double(*CMMetricFunc)(double, double, double, double);
+
+  #define CM_STATS_COLS 9
+
   double mcc(double tp, double tn, double fp, double fn) {
     auto n = tp + tn + fp + fn;
     auto s = (tp + fn) / n;
@@ -32,8 +34,8 @@ namespace h2o4gpu {
     return (std::abs(y) < 1E-15) ? 0.0 : (2 * tp) / y;
   }
 
-  double roc_based_metric_opt(std::vector<double> y, std::vector<double> yhat,
-    std::vector<double> w, MetricFunc metric) {
+  double cm_metric_opt(std::vector<double> y, std::vector<double> yhat,
+                       std::vector<double> w, CMMetricFunc metric) {
     auto idx = argsort(yhat);
     int n = static_cast<int>(y.size());
     double tp = 0;
@@ -67,28 +69,82 @@ namespace h2o4gpu {
     }
     return best_score;
   }
-
+  
+  void cm_stats(std::vector<double> y, std::vector<double> yhat, std::vector<double> w,
+                double cm[][CM_STATS_COLS]) {
+    auto idx = argsort(yhat);
+    int n = static_cast<int>(y.size());
+    double tp = 0;
+    double tn = 0;
+    double fp = 0;
+    double fn = 0;
+    std::vector<double> y_sorted;
+    std::vector<double> w_sorted;
+    for (auto &i : idx) {
+      y_sorted.push_back(y[i]);
+      w_sorted.push_back(w[i]);
+      auto label = static_cast<int>(y[i]);
+      tp += w[i] * label;
+      fp += w[i] * (1 - label);
+    }
+    double prev_proba = -1;
+    int k = 0;
+    for (int i = 0; i < n; ++i) {
+      auto proba = yhat[idx[i]];
+      if (proba != prev_proba) {
+        prev_proba = proba;
+        cm[k][0] = proba;
+        cm[k][1] = tp;
+        cm[k][2] = tn;
+        cm[k][3] = fp;
+        cm[k][4] = fn;
+        cm[k][5] = fp / (fp + tn); // fpr
+        cm[k][6] = tp / (tp + fn); // tpr
+        cm[k][7] = mcc(tp, tn, fp, fn);
+        cm[k][8] = f1(tp, tn, fp, fn);
+        k += 1;
+      }
+      if (static_cast<int>(y_sorted[i]) == 1) {
+        tp -= w_sorted[i];
+        fn += w_sorted[i];
+      }
+      else {
+        tn += w_sorted[i];
+        fp -= w_sorted[i];
+      }
+    }
+  }
 
   double mcc_opt(double *y, int n, double *yhat, int m) {
     std::vector<double> w(n, 1.0);
-    return roc_based_metric_opt(std::vector<double>(y, y + n),
-                                std::vector<double>(yhat, yhat + m), w, mcc);
+    return cm_metric_opt(std::vector<double>(y, y + n), std::vector<double>(yhat, yhat + m),
+                         w, mcc);
   }
   
   double mcc_opt(double *y, int n, double *yhat, int m, double *w, int l) {
-    return roc_based_metric_opt(std::vector<double>(y, y + n),
-      std::vector<double>(yhat, yhat + m), std::vector<double>(w, w + l), mcc);
+    return cm_metric_opt(std::vector<double>(y, y + n), std::vector<double>(yhat, yhat + m),
+                         std::vector<double>(w, w + l), mcc);
   }
 
   double f1_opt(double *y, int n, double *yhat, int m) {
     std::vector<double> w(n, 1.0);
-    return roc_based_metric_opt(std::vector<double>(y, y + n),
-                                std::vector<double>(yhat, yhat + m), w, f1);
+    return cm_metric_opt(std::vector<double>(y, y + n), std::vector<double>(yhat, yhat + m),
+                         w, f1);
   }
 
   double f1_opt(double *y, int n, double *yhat, int m, double *w, int l) {
-    return roc_based_metric_opt(std::vector<double>(y, y + n),
-      std::vector<double>(yhat, yhat + m), std::vector<double>(w, w + l), f1);
+    return cm_metric_opt(std::vector<double>(y, y + n), std::vector<double>(yhat, yhat + m),
+                         std::vector<double>(w, w + l), f1);
+  }
+  
+  void confusion_matrices(double *y, int n, double *yhat, int m, double *cm, int k, int j) {
+    std::vector<double> w(n, 1.0);
+    cm_stats(std::vector<double>(y, y + n), std::vector<double>(yhat, yhat + m),
+             w, reinterpret_cast<double(*)[CM_STATS_COLS]>(cm));
   }
 
+  void confusion_matrices(double *y, int n, double *yhat, int m, double* w, int l, double *cm, int k, int j) {
+    cm_stats(std::vector<double>(y, y + n), std::vector<double>(yhat, yhat + m),
+             std::vector<double>(w, w + l), reinterpret_cast<double(*)[CM_STATS_COLS]>(cm));
+  }
 }

--- a/src/include/metrics/metrics.h
+++ b/src/include/metrics/metrics.h
@@ -13,6 +13,9 @@ namespace h2o4gpu {
   double f1_opt(double *y, int n, double *yhat, int m);
   double f1_opt(double *y, int n, double *yhat, int m, double* w, int l);
   
+  void confusion_matrices(double *y, int n, double *yhat, int m, double *cm, int k, int j);
+  void confusion_matrices(double *y, int n, double *yhat, int m, double* w, int l, double *cm, int k, int j);
+  
 }
 
 #endif

--- a/src/interface_py/Makefile
+++ b/src/interface_py/Makefile
@@ -6,7 +6,7 @@ default: all
 pylint:
 	@status=0; \
 	for py in $$(find h2o4gpu -name "*.py" -type f); do \
-		if [ "$$py" == "h2o4gpu/__init__.py" ] || [ "$$py" == "h2o4gpu/util/roc_opt.py" ]; \
+		if [ "$$py" == "h2o4gpu/__init__.py" ] || [ "$$py" == "h2o4gpu/util/daicx.py" ]; \
 		then echo "Skip $$py"; \
 		else echo $$py; \
 		mkdir -p ../pylint.d ; PYLINTHOME=../pylint.d pylint --rcfile=../../tools/pylintrc -rn $$py; \

--- a/src/interface_py/h2o4gpu/util/daicx.i
+++ b/src/interface_py/h2o4gpu/util/daicx.i
@@ -1,4 +1,4 @@
-%module roc_opt
+%module daicx
 %{
   #define SWIG_FILE_WITH_INIT
   #include "../include/metrics/metrics.h"
@@ -12,4 +12,6 @@ import_array();
 %apply (double* IN_ARRAY1, int DIM1) {(double *y, int n), 
                                       (double *yhat, int m), 
                                       (double *w, int l)};
+%apply (double* INPLACE_ARRAY2, int DIM1, int DIM2) {(double *cm, int k, int j)};
+
 %include "../include/metrics/metrics.h"

--- a/src/interface_py/setup.py
+++ b/src/interface_py/setup.py
@@ -111,7 +111,7 @@ setup(
     author_email='h2ostream@googlegroups.com',
     url='http://h2o.ai',
     distclass=BinaryDistribution,
-    #platforms=['linux_x86_64'], # scikit-learn: h2o4gpu-0.20.dev0-cp36-cp36m-linux_x86_64.whl
+    # platforms=['linux_x86_64'], # scikit-learn: h2o4gpu-0.20.dev0-cp36-cp36m-linux_x86_64.whl
     # from:
     # find -L -type d -printf '%d\t%P\n'| sort -r -nk1| cut -f2-|grep -v pycache
     packages=packages,
@@ -123,8 +123,8 @@ setup(
     cmdclass={'build': H2O4GPUBuild, 'install': H2O4GPUInstall},
     
     ext_modules=[
-    Extension(name='h2o4gpu.util._roc_opt',
-              sources=['h2o4gpu/util/roc_opt.i', '../cpu/metrics/metrics.cpp'],
+    Extension(name='h2o4gpu.util._daicx',
+              sources=['h2o4gpu/util/daicx.i', '../cpu/metrics/metrics.cpp'],
               include_dirs=[numpy.get_include(), '../include/'],
               extra_compile_args=swig_extra_compile_args,
               extra_link_args=swig_extra_link_args,


### PR DESCRIPTION
Extends h2o4gpu.util.metrics by `def confusion_matrices(actual, predicted, sample_weight=None)` in order to calculate confusion matrices for each unique predicted value as probability cutoff.

complexity: *O*(n log n)
example:
```
y = np.array([0, 0, 0, 0 ,0, 1, 1, 1, 1, 1])
yhat = np.array([0.1, 0.5, 0.95, 0.2, 0.7, 0.95, 0.23, 0.42, 0.98, 0.01])
print(confusion_matrices(y, yhat))
"""
  p    tp   tn   fp   fn   fpr  tpr   mcc  f1
0 0.01 5.00 0.00 5.00 0.00 1.00 1.00  0.00 0.67
1 0.10 4.00 0.00 5.00 1.00 1.00 0.80 -0.33 0.57
2 0.20 4.00 1.00 4.00 1.00 0.80 0.80  0.00 0.62
3 0.23 4.00 2.00 3.00 1.00 0.60 0.80  0.22 0.67
4 0.42 3.00 2.00 3.00 2.00 0.60 0.60  0.00 0.55
5 0.50 2.00 2.00 3.00 3.00 0.60 0.40 -0.20 0.40
6 0.70 2.00 3.00 2.00 3.00 0.40 0.40  0.00 0.44
7 0.95 2.00 4.00 1.00 3.00 0.20 0.40  0.22 0.50
8 0.98 1.00 5.00 0.00 4.00 0.00 0.20  0.33 0.33
"""
```




