### PR TITLE
Fixes #404: Use older version of testthat to avoid false positives

### DIFF
--- a/scripts/install_r_deps.sh
+++ b/scripts/install_r_deps.sh
@@ -15,5 +15,5 @@ else
 fi
 
 echo "Installing necessary R packages..."
-R -e 'options(repos = c(CRAN = "http://cran.rstudio.com")); pkgs <- c("devtools", "testthat", "magrittr", "roxygen2"); pkgs_to_install <- pkgs[!pkgs %in% row.names(installed.packages())]; if (length(pkgs_to_install) != 0) install.packages(pkgs_to_install); if (!require("reticulate")) devtools::install_github("rstudio/reticulate")'
+R -e 'options(repos = c(CRAN = "http://cran.rstudio.com")); pkgs <- c("devtools", "magrittr", "roxygen2"); pkgs_to_install <- pkgs[!pkgs %in% row.names(installed.packages())]; if (length(pkgs_to_install) != 0) install.packages(pkgs_to_install); if (!require("reticulate")) devtools::install_github("rstudio/reticulate"); if (!require("testthat")) devtools::install_github("r-lib/testthat@v1.0.2")'
 R -e 'devtools::install_local("src/interface_r/")'

--- a/src/interface_r/tests/testthat/test_model.R
+++ b/src/interface_r/tests/testthat/test_model.R
@@ -1,22 +1,22 @@
-# context("Test h2o4gpu_model methods")
-# 
-# source("helper-utils.R")
-# 
-# test_generic_methods <- function(input) {
-#   model <- h2o4gpu.kmeans(n_clusters = 2, random_state = 1234) %>% fit(input)
-#   expect_equal(dim(model$cluster_centers_), c(2, 2))
-#   expect_equal(dim(model %>% predict(input)), 3)
-#   expect_equal(dim(model %>% transform(input)), c(3, 2))
-# }
-# 
-# test_succeeds("Generic methods for model work correctly for different types of inputs", {
-#   raw_input <- list(list(1, 1), list(1, 4), list(1, 0))
-#   x <- np$array(raw_input)
-#   
-#   # Test support for data.frame
-#   test_generic_methods(as.data.frame(x))
-#   # Test support for list
-#   test_generic_methods(raw_input)
-#   # Test support for matrix/np.array
-#   test_generic_methods(x)
-# })
+context("Test h2o4gpu_model methods")
+
+source("helper-utils.R")
+
+test_generic_methods <- function(input) {
+  model <- h2o4gpu.kmeans(n_clusters = 2, random_state = 1234) %>% fit(input)
+  expect_equal(dim(model$cluster_centers_), c(2, 2))
+  expect_equal(dim(model %>% predict(input)), 3)
+  expect_equal(dim(model %>% transform(input)), c(3, 2))
+}
+
+test_succeeds("Generic methods for model work correctly for different types of inputs", {
+  raw_input <- list(list(1, 1), list(1, 4), list(1, 0))
+  x <- np$array(raw_input)
+
+  # Test support for data.frame
+  test_generic_methods(as.data.frame(x))
+  # Test support for list
+  test_generic_methods(raw_input)
+  # Test support for matrix/np.array
+  test_generic_methods(x)
+})


### PR DESCRIPTION
The newer version of testthat v2.0.0 has an issue with . This issue won't exist for users though. It only happens inside a testthat block. 