### PR TITLE
Document and extract requirements that need root level access

### DIFF
--- a/DEVEL.md
+++ b/DEVEL.md
@@ -33,6 +33,12 @@ pip install setuptools --no-cache-dir
 sudo apt-get install -y libopenblas-dev pbzip2 swig
 ```
 
+If you are building the h2o4gpu R package, it is necessary to install the following dependencies:
+
+```
+sudo apt-get -y install libcurl4-openssl-dev libssl-dev libxml2-dev
+```
+
 If you are using `conda`, you probably need to do:
 ```
 conda install libgcc

--- a/Dockerfile-build
+++ b/Dockerfile-build
@@ -75,4 +75,7 @@ RUN \
 # Install R dependencies and h2o4gpu R package
 COPY scripts/install_r.sh scripts/install_r.sh
 COPY scripts/install_r_deps.sh scripts/install_r_deps.sh
-RUN scripts/install_r_deps.sh
+RUN \
+    apt-get update -y && \
+    apt-get -y install libcurl4-openssl-dev libssl-dev libxml2-dev && \
+    scripts/install_r_deps.sh

--- a/README.md
+++ b/README.md
@@ -32,6 +32,8 @@ Ensure to reboot after installing the new nvidia drivers.
 
 * For advanced features, like handling rows/32 > 2^16 (i.e., rows > 2,097,152) in K-means, need Capability >= 5.2
 
+* For building the R package, `libcurl4-openssl-dev`, `libssl-dev`, and `libxml2-dev` are needed.
+
 ## User Installation
 
 Note: This installation is for users who download the wheel file and are not expecting to develop the code.  See [DEVEL.md](DEVEL.md) for developer installation.
@@ -47,6 +49,12 @@ export LD_LIBRARY_PATH=$LD_LIBRARY_PATH:$CUDA_HOME/lib64/:$CUDA_HOME/lib/:$CUDA_
 
 ```
 sudo apt-get install libopenblas-dev pbzip2
+```
+
+If you are building the h2o4gpu R package, it is necessary to install the following dependencies:
+
+```
+sudo apt-get -y install libcurl4-openssl-dev libssl-dev libxml2-dev
 ```
 
 Download the Python wheel file (For Python 3.6 on linux_x86_64):

--- a/scripts/install_r.sh
+++ b/scripts/install_r.sh
@@ -18,7 +18,7 @@ rm R-${R_VERSION}.tar.gz
 # Configure and make
 cd R-${R_VERSION}
 ./configure --prefix=${R_VERSION_HOME} --with-x=no --enable-utf
-make
+make -j
 make install
 chmod a+w -R ${R_VERSION_HOME}/lib/R/library
 

--- a/scripts/install_r_deps.sh
+++ b/scripts/install_r_deps.sh
@@ -2,10 +2,6 @@
 
 DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
 
-echo "Installing necessary apt-get dependencies..."
-apt-get update -y
-apt-get -y install libcurl4-openssl-dev libssl-dev libxml2-dev
-
 R_BIN=$(which R)
 if [[ $? != 0 ]]; then
   echo "R is not installed. Installing..."


### PR DESCRIPTION
- These apt-get commands require root access so I extracted them out
- Change `make` to `make -j` so the build is faster
