### PR TITLE
Calculate explained variance in CUDA instead of Python for power method

### DIFF
--- a/src/interface_py/h2o4gpu/solvers/truncated_svd.py
+++ b/src/interface_py/h2o4gpu/solvers/truncated_svd.py
@@ -127,14 +127,8 @@ class TruncatedSVDH2O(object):
         self._U = U
         self._X = X
         X_transformed = U * w
-        # TODO Investigate why explained variance/ratio are off in cuda
-        if self.algorithm != "power":
-            self.explained_variance = explained_variance
-            self.explained_variance_ratio = explained_variance_ratio
-        else:
-            self.explained_variance = np.var(X_transformed, axis=0)
-            full_var = np.var(X, axis=0).sum()
-            self.explained_variance_ratio = self.explained_variance / full_var
+        self.explained_variance = explained_variance
+        self.explained_variance_ratio = explained_variance_ratio
         return X_transformed
 
     def transform(self, X):


### PR DESCRIPTION
* Tests now pass for explained variance in tsvd. Need to increase n_iter to 100
* Should fix #416 