### PR TITLE
Make R installation optional based on INSTALL_R env var

### DIFF
--- a/Dockerfile-build
+++ b/Dockerfile-build
@@ -79,8 +79,9 @@ RUN \
     pip install -r requirements_runtime.txt && \
     pip install -r requirements_runtime_demos.txt
 
-# Install R dependencies and h2o4gpu R package
+# Install R dependencies and h2o4gpu R package when appropriate
 COPY scripts/install_r.sh scripts/install_r.sh
+COPY scripts/test_r_pkg.sh scripts/test_r_pkg.sh
 COPY scripts/install_r_deps.sh scripts/install_r_deps.sh
 RUN \
     apt-get update -y && \

--- a/Makefile
+++ b/Makefile
@@ -255,7 +255,7 @@ fullinstall-nonccl-cuda9: clean alldeps-nonccl-cuda9 build install
 
 fullinstall-cpuonly: clean alldeps-cpuonly build install
 	mkdir -p src/interface_py/dist-cpuonly-local/ && mv src/interface_py/dist/*.whl src/interface_py/dist-cpuonly-local/
-	
+
 ####################################################
 # Docker stuff
 
@@ -351,7 +351,7 @@ docker-runtime-cpu:
 	export buckettype="releases/bleeding-edge" ;\
 	export dockerimage="ubuntu:16.04" ;\
 	bash scripts/make-docker-runtime.sh
-	
+
 docker-runtime-cpu-run:
 	@echo "+-Running Docker Runtime Image (-nccl-cuda9) --+"
 	export CONTAINER_NAME="localmake-runtime-run" ;\
@@ -381,7 +381,7 @@ docker-runtime-cpu-load:
 run_in_docker-cpu:
 	-mkdir -p log ; docker run --name localhost --rm -p 8888:8888 -u `id -u`:`id -g` -v `pwd`/log:/log --entrypoint=./run.sh opsh2oai/h2o4gpu-$(BASE_VERSION)-cpu-runtime &
 	-find log -name jupyter* -type f -printf '%T@ %p\n' | sort -k1 -n | awk '{print $2}' | tail -1 | xargs cat | grep token | grep http | grep -v NotebookApp
-	
+
 
 ######### CUDA8 (copy/paste above, and then replace cuda9 -> cuda8 and cuda:9.0-cudnn7 -> cuda:8.0-cudnn5 and dist4->dist1)
 
@@ -573,8 +573,8 @@ dotest:
 	mkdir -p ./tmp/
   # can't do -n auto due to limits on GPU memory
 	pytest -s --verbose --durations=10 -n 3 --fulltrace --full-trace --junit-xml=build/test-reports/h2o4gpu-test.xml tests_open 2> ./tmp/h2o4gpu-test.$(LOGEXT).log
-	# Test R package
-	R -e 'devtools::test("src/interface_r")'
+	# Test R package when appropriate
+	bash scripts/test_r_pkg.sh
 
 dotestfast:
 	rm -rf ./tmp/

--- a/make/config.mk
+++ b/make/config.mk
@@ -28,8 +28,12 @@ OPEN_DATA_DIR = open_data
 #
 #PYDATATABLE_VERSION = 0.1.0+master.97
 
-
 #
 # XGBoost
 #
 XGBOOST_VERSION = 0.6
+
+#
+# R package Configurations
+#
+INSTALL_R = 1

--- a/make/config.mk
+++ b/make/config.mk
@@ -37,3 +37,4 @@ XGBOOST_VERSION = 0.6
 # R package Configurations
 #
 INSTALL_R = 1
+R_VERSION = 3.1.0

--- a/scripts/install_r_deps.sh
+++ b/scripts/install_r_deps.sh
@@ -9,7 +9,7 @@ else
   echo "INSTALL_R is set to be non-zero. Installing R dependencies..."
   if [[ $? != 0 ]]; then
     echo "R is not installed. Installing..."
-    $DIR/install_r.sh 3.1.0
+    $DIR/install_r.sh $R_VERSION
   else
     echo "R is installed."
   fi

--- a/scripts/install_r_deps.sh
+++ b/scripts/install_r_deps.sh
@@ -2,14 +2,19 @@
 
 DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
 
-R_BIN=$(which R)
-if [[ $? != 0 ]]; then
-  echo "R is not installed. Installing..."
-  $DIR/install_r.sh 3.1.0
+if [[ $INSTALL_R == 0 ]] || [[ -z ${INSTALL_R+x} ]]; then
+  echo "INSTALL_R is either unset or set to be 0. Skipping R installation."
 else
-  echo "R is installed."
-fi
+  R_BIN=$(which R)
+  echo "INSTALL_R is set to be non-zero. Installing R dependencies..."
+  if [[ $? != 0 ]]; then
+    echo "R is not installed. Installing..."
+    $DIR/install_r.sh 3.1.0
+  else
+    echo "R is installed."
+  fi
 
-echo "Installing necessary R packages..."
-R -e 'options(repos = c(CRAN = "http://cran.rstudio.com")); pkgs <- c("devtools", "magrittr", "roxygen2"); pkgs_to_install <- pkgs[!pkgs %in% row.names(installed.packages())]; if (length(pkgs_to_install) != 0) install.packages(pkgs_to_install); if (!require("reticulate")) devtools::install_github("rstudio/reticulate"); if (!require("testthat")) devtools::install_github("r-lib/testthat@v1.0.2")'
-R -e 'devtools::install_local("src/interface_r/")'
+  echo "Installing necessary R packages..."
+  R -e 'options(repos = c(CRAN = "http://cran.rstudio.com")); pkgs <- c("devtools", "magrittr", "roxygen2"); pkgs_to_install <- pkgs[!pkgs %in% row.names(installed.packages())]; if (length(pkgs_to_install) != 0) install.packages(pkgs_to_install); if (!require("reticulate")) devtools::install_github("rstudio/reticulate"); if (!require("testthat")) devtools::install_github("r-lib/testthat@v1.0.2")'
+  R -e 'devtools::install_local("src/interface_r/")'
+fi

--- a/scripts/test_r_pkg.sh
+++ b/scripts/test_r_pkg.sh
@@ -1,0 +1,11 @@
+#!/bin/bash
+
+DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
+
+R_BIN=$(which R)
+if [[ $? != 0 ]]; then
+  echo "R is not installed. Skipping R tests..."
+else
+  echo "R is installed. Running R tests..."
+  R -e 'pkgs <- c("devtools", "magrittr", "roxygen2", "reticulate", "testthat"); if (isTRUE(all(pkgs %in% row.names(installed.packages())))) devtools::test("src/interface_r")'
+fi


### PR DESCRIPTION
This is to address the issue when installing R while trying to make h2o4gpu work for DAI on various native builds. 

* `make fullinstall` should now install R only when `INSTALL_R = 1`.  In other words, `INSTALL_R = 0` is the default so `make fulllinstall` won't install R dependencies now unless you do `make INSTALL_R=1 fullinstall`

* R tests will only run when R is available AND all the necessary R dependencies are available. 

* Allow R version to be conconfigurable prior to installation via `R_VERSION` env var.