### PR TITLE
Modify predict method in R to account for probabilities and update predict_proba in Py API

### DIFF
--- a/src/interface_py/h2o4gpu/solvers/daal_solver/svd.py
+++ b/src/interface_py/h2o4gpu/solvers/daal_solver/svd.py
@@ -7,8 +7,8 @@
 from __future__ import print_function
 import sys
 from enum import Enum
-from daal.algorithms import svd
 import numpy as np
+from daal.algorithms import svd
 from .daal_data import IInput
 
 __all__ = ['SingularValueParameter', 'SVD']

--- a/src/interface_py/h2o4gpu/solvers/elastic_net.py
+++ b/src/interface_py/h2o4gpu/solvers/elastic_net.py
@@ -343,9 +343,10 @@ class ElasticNetH2O(object):
         :param int free_input_data : Indicate if input data should be freed at
             the end of fit(). Default is 1.
         """
-        res = self.predict_proba(self, valid_x,valid_y, sample_weight, free_input_data)
-        res[res < 0.5] = 0
-        res[res > 0.5] = 1
+        res = self.predict_proba(valid_x, valid_y, sample_weight, free_input_data)
+        if self.family == "logistic":
+            res[res < 0.5] = 0
+            res[res > 0.5] = 1
         return res
 
     def predict_proba(self,

--- a/src/interface_py/h2o4gpu/solvers/elastic_net.py
+++ b/src/interface_py/h2o4gpu/solvers/elastic_net.py
@@ -326,13 +326,34 @@ class ElasticNetH2O(object):
         return self
 
 #TODO Add typechecking
-
     def predict(self,
                 valid_x=None,
                 valid_y=None,
                 sample_weight=None,
                 free_input_data=1):
-        """Predict on a fitted GLM
+        """Predict on a fitted GLM and get back class predictions for binomial models
+        for classification and predicted values for regression.
+
+        :param ndarray valid_x : Validation features
+
+        :param ndarray valid_y : Validation response
+
+        :param ndarray weight : Observation weights
+
+        :param int free_input_data : Indicate if input data should be freed at
+            the end of fit(). Default is 1.
+        """
+        res = self.predict_proba(self, valid_x,valid_y, sample_weight, free_input_data)
+        res[res < 0.5] = 0
+        res[res > 0.5] = 1
+        return res
+
+    def predict_proba(self,
+                valid_x=None,
+                valid_y=None,
+                sample_weight=None,
+                free_input_data=1):
+        """Predict on a fitted GLM and get back uncalibrated probabilities for classification models
 
         :param ndarray valid_x : Validation features
 

--- a/src/interface_py/h2o4gpu/solvers/elastic_net.py
+++ b/src/interface_py/h2o4gpu/solvers/elastic_net.py
@@ -350,10 +350,10 @@ class ElasticNetH2O(object):
         return res
 
     def predict_proba(self,
-                valid_x=None,
-                valid_y=None,
-                sample_weight=None,
-                free_input_data=1):
+                      valid_x=None,
+                      valid_y=None,
+                      sample_weight=None,
+                      free_input_data=1):
         """Predict on a fitted GLM and get back uncalibrated probabilities for classification models
 
         :param ndarray valid_x : Validation features

--- a/src/interface_py/h2o4gpu/solvers/xgboost.py
+++ b/src/interface_py/h2o4gpu/solvers/xgboost.py
@@ -325,8 +325,6 @@ class RandomForestClassifier(object):
             self.set_attributes()
             return res
         res = self.model.predict(X)
-        res[res < 0.5] = 0
-        res[res > 0.5] = 1
         self.set_attributes()
         return res.squeeze()
 
@@ -341,7 +339,7 @@ class RandomForestClassifier(object):
             res = self.model.predict_proba(X)
             self.set_attributes()
             return res
-        res = self.model.predict(X)
+        res = self.model.predict_proba(X)
         self.set_attributes()
         return res
 

--- a/src/interface_r/R/model.R
+++ b/src/interface_r/R/model.R
@@ -92,12 +92,16 @@ fit.h2o4gpu_model <- function(object, x, y = NULL, ...) {
 #' @export
 predict.h2o4gpu_model <- function(object, x, type="raw", ...) {
   if (type == "raw") {
-    object$model$predict(X = resolve_model_input(x), ...)
+    preds <- object$model$predict(X = resolve_model_input(x), ...)
   } else if (type == "prob") {
-    object$model$predict_proba(X = resolve_model_input(x), ...)
+    preds <- object$model$predict_proba(X = resolve_model_input(x), ...)
+    if (!is.null(object$classes_)){
+      colnames(preds) <- object$classes_ #Taken from tree based models
+    }
   } else {
     stop(paste0("Unrecognized 'type' parameter value. Expected either 'raw' or 'prob but got ", type))
   }
+  return(preds)
 }
 
 #' Transform a Dataset using Trained H2O4GPU Estimator

--- a/src/interface_r/R/model.R
+++ b/src/interface_r/R/model.R
@@ -81,15 +81,23 @@ fit.h2o4gpu_model <- function(object, x, y = NULL, ...) {
 
 #' Make Predictions using Trained H2O4GPU Estimator
 #' 
-#' This function makes predictions from new data using a trained H2O4GPU model.
+#' This function makes predictions from new data using a trained H2O4GPU model and returns class predictions
+#' for classification and predicted values for regression.
 #' 
 #' @param object The h2o4gpu model object
 #' @param x The new data where each column represents a different predictor variable to 
 #' be used in generating predictions.
+#' @param type One of "response" or "prob", indicating the type of output: predicted values or probabilities
 #' @param ... Additional arguments (unused for now).
 #' @export
-predict.h2o4gpu_model <- function(object, x, ...) {
-  object$model$predict(X = resolve_model_input(x), ...)
+predict.h2o4gpu_model <- function(object, x, type="response", ...) {
+  if (type == "response") {
+    object$model$predict(X = resolve_model_input(x), ...)
+  } else if (type == "prob") {
+    object$model$predict_proba(X = resolve_model_input(x), ...)
+  } else {
+    stop(paste0("Unrecognized 'type' parameter value. Expected either 'response' or 'prob but got ", type))
+  }
 }
 
 #' Transform a Dataset using Trained H2O4GPU Estimator

--- a/src/interface_r/R/model.R
+++ b/src/interface_r/R/model.R
@@ -87,16 +87,16 @@ fit.h2o4gpu_model <- function(object, x, y = NULL, ...) {
 #' @param object The h2o4gpu model object
 #' @param x The new data where each column represents a different predictor variable to 
 #' be used in generating predictions.
-#' @param type One of "response" or "prob", indicating the type of output: predicted values or probabilities
+#' @param type One of "raw" or "prob", indicating the type of output: predicted values or probabilities
 #' @param ... Additional arguments (unused for now).
 #' @export
-predict.h2o4gpu_model <- function(object, x, type="response", ...) {
-  if (type == "response") {
+predict.h2o4gpu_model <- function(object, x, type="raw", ...) {
+  if (type == "raw") {
     object$model$predict(X = resolve_model_input(x), ...)
   } else if (type == "prob") {
     object$model$predict_proba(X = resolve_model_input(x), ...)
   } else {
-    stop(paste0("Unrecognized 'type' parameter value. Expected either 'response' or 'prob but got ", type))
+    stop(paste0("Unrecognized 'type' parameter value. Expected either 'raw' or 'prob but got ", type))
   }
 }
 

--- a/src/interface_r/man/predict.h2o4gpu_model.Rd
+++ b/src/interface_r/man/predict.h2o4gpu_model.Rd
@@ -4,7 +4,7 @@
 \alias{predict.h2o4gpu_model}
 \title{Make Predictions using Trained H2O4GPU Estimator}
 \usage{
-\method{predict}{h2o4gpu_model}(object, x, ...)
+\method{predict}{h2o4gpu_model}(object, x, type = "raw", ...)
 }
 \arguments{
 \item{object}{The h2o4gpu model object}
@@ -12,8 +12,11 @@
 \item{x}{The new data where each column represents a different predictor variable to
 be used in generating predictions.}
 
+\item{type}{One of "raw" or "prob", indicating the type of output: predicted values or probabilities}
+
 \item{...}{Additional arguments (unused for now).}
 }
 \description{
-This function makes predictions from new data using a trained H2O4GPU model.
+This function makes predictions from new data using a trained H2O4GPU model and returns class predictions
+for classification and predicted values for regression.
 }


### PR DESCRIPTION
* Resolves https://github.com/h2oai/h2o4gpu/issues/433 by adding a `type` argument to `predict()` with values of "raw" (default; vector of predictions) or "prob" (matrix of uncalibrated class probabilities).  The values of "raw" and "prob" come from the caret R package.
* Sample output in R:
```{r}
predictions <- model %>% predict(x, type = "prob")
head(predictions)
             0         1
[1,] 0.3294092 0.6705908
[2,] 0.3176789 0.6823211
[3,] 0.3176789 0.6823211
[4,] 0.4417148 0.5582852
[5,] 0.4781650 0.5218350
[6,] 0.6315404 0.3684596
```

* New `predict` API:
```{r}
#' Make Predictions using Trained H2O4GPU Estimator
#' 
#' This function makes predictions from new data using a trained H2O4GPU model and returns class predictions
#' for classification and predicted values for regression.
#' 
#' @param object The h2o4gpu model object
#' @param x The new data where each column represents a different predictor variable to 
#' be used in generating predictions.
#' @param type One of "raw" or "prob", indicating the type of output: predicted values or probabilities
#' @param ... Additional arguments (unused for now).
#' @export
predict.h2o4gpu_model <- function(object, x, type="raw", ...) {
  if (type == "raw") {
    preds <- object$model$predict(X = resolve_model_input(x), ...)
  } else if (type == "prob") {
    preds <- object$model$predict_proba(X = resolve_model_input(x), ...)
    if (!is.null(object$classes_)){
      colnames(preds) <- object$classes_ #Taken from tree based models
    }
  } else {
    stop(paste0("Unrecognized 'type' parameter value. Expected either 'raw' or 'prob but got ", type))
  }
  return(preds)
}
```