### PR TITLE
CMake 3.11+SWIG missing file/target fix

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -71,8 +71,6 @@ TARGET_LINK_LIBRARIES(cpuh2o4gpu ${BLAS_LIBRARIES})
 
 #============= SWIG
 SET(CMAKE_SWIG_FLAGS "")
-SET(CMAKE_LIBRARY_OUTPUT_DIRECTORY "../src/interface_c/")
-SET(CMAKE_SWIG_OUTDIR "../src/interface_py/h2o4gpu/libs")
 #============= SWIG
 
 #============= CPU SWIG

--- a/Makefile
+++ b/Makefile
@@ -119,7 +119,14 @@ update_submodule:
 	echo ADD UPDATE SUBMODULE HERE
 
 cpp:
-	(mkdir -p build; cd build; cmake ../; make -j)
+	(mkdir -p build; \
+	cd build; \
+	touch ../src/interface_py/h2o4gpu/libs/ch2o4gpu_cpuPYTHON_wrap.stamp; \
+	touch ../src/interface_py/h2o4gpu/libs/ch2o4gpu_gpuPYTHON_wrap.stamp; \
+	cmake ../; \
+	make -j; \
+	rm -f ../src/interface_py/h2o4gpu/libs/ch2o4gpu_cpuPYTHON_wrap.stamp; \
+	rm -f ../src/interface_py/h2o4gpu/libs/ch2o4gpu_gpuPYTHON_wrap.stamp); \
 
 py: apply-sklearn_simple build/VERSION.txt
 	$(MAKE) -j all -C src/interface_py

--- a/Makefile
+++ b/Makefile
@@ -121,12 +121,10 @@ update_submodule:
 cpp:
 	(mkdir -p build; \
 	cd build; \
-	touch ../src/interface_py/h2o4gpu/libs/ch2o4gpu_cpuPYTHON_wrap.stamp; \
-	touch ../src/interface_py/h2o4gpu/libs/ch2o4gpu_gpuPYTHON_wrap.stamp; \
 	cmake ../; \
 	make -j; \
-	rm -f ../src/interface_py/h2o4gpu/libs/ch2o4gpu_cpuPYTHON_wrap.stamp; \
-	rm -f ../src/interface_py/h2o4gpu/libs/ch2o4gpu_gpuPYTHON_wrap.stamp); \
+	cp _ch2o4gpu_*pu.so ../src/interface_c/; \
+	cp ch2o4gpu_*pu.py ../src/interface_py/h2o4gpu/libs;)
 
 py: apply-sklearn_simple build/VERSION.txt
 	$(MAKE) -j all -C src/interface_py


### PR DESCRIPTION
CMake 3.11 seems to have some SWIG issues, need to move generated files (`.so` and SWIG Python modules) manually for now.