### PR TITLE
Downgrade Pillow version in Centos Docker to the same version as in Python reqs

### DIFF
--- a/Dockerfile-build-centos7.in
+++ b/Dockerfile-build-centos7.in
@@ -101,14 +101,15 @@ RUN bash -c 'if [ `arch` = "ppc64le" ]; then \
 	yum install -y libjpeg-devel; \
 	fi'
 
+ENV PILLOW_VERSION=4.2.1
 RUN bash -c 'if [ `arch` = "ppc64le" ]; then \
-	wget https://pypi.python.org/packages/0f/57/25be1a4c2d487942c3ed360f6eee7f41c5b9196a09ca71c54d1a33c968d9/Pillow-5.0.0.tar.gz#md5=08094bc48aae6877c94f8db4b8ee8e52 && \
-	tar xvf Pillow-5.0.0.tar.gz && \
-	cd $HOME/Pillow-5.0.0 && \
+	wget https://files.pythonhosted.org/packages/55/aa/f7f983fb72710a9daa4b3374b7c160091d3f94f5c09221f9336ade9027f3/Pillow-${PILLOW_VERSION}.tar.gz && \
+	tar xvf Pillow-${PILLOW_VERSION}.tar.gz && \
+	cd $HOME/Pillow-${PILLOW_VERSION} && \
 	sed -i "s/'ppc64'/'ppc64le'/g" setup.py && \
 	python3.6 setup.py install && \
 	cd $HOME && \
-	rm -rf Pillow-5.0.0*; \
+	rm -rf Pillow-${PILLOW_VERSION}*; \
 	fi'
 
 # Symlinks for NVML


### PR DESCRIPTION
Seems they don't publish wheels for Pillow for ppc64le so we need to make our "own whl", the latest change in Python requirements requires a very specific version so need to downgrade in Docker for centos.