### PR TITLE
Add svd sign correction to CUDA backend

### DIFF
--- a/src/gpu/data/matrix.cu
+++ b/src/gpu/data/matrix.cu
@@ -1,9 +1,36 @@
 #include "matrix.cuh"
 #include <algorithm>
 #include <thrust/inner_product.h>
+#include <thrust/extrema.h>
 
 namespace tsvd
 {
+	void max_index_per_column(Matrix<tsvd_float>& A, std::vector<int>& result_array, DeviceContext& context){
+
+		int result;
+		for (int i=0; i<A.columns(); i++) {
+			safe_cublas(cublasIsamax(context.cublas_handle, A.rows(), A.data() + i*A.rows(), 1, &result));
+			if (i == 0) {
+				result_array[i] = result - 1;
+			} else  {
+				result_array[i] = result - 1 + A.rows();
+			}
+		}
+	}
+
+	void max_index_per_column(Matrix<tsvd_double>& A, std::vector<int>& result_array, DeviceContext& context){
+
+		int result;
+		for (int i=0; i<A.columns(); i++) {
+			safe_cublas(cublasIdamax(context.cublas_handle, A.rows(), A.data() + i*A.rows(), 1, &result));
+			if (i == 0) {
+				result_array[i] = result - 1;
+			} else  {
+				result_array[i] = result - 1 + A.rows();
+			}
+		}
+	}
+
 	template<typename T, typename U>
 	void multiply(Matrix<T>& A, const U a, DeviceContext& context)
 	{

--- a/src/gpu/data/matrix.cuh
+++ b/src/gpu/data/matrix.cuh
@@ -469,6 +469,9 @@ namespace tsvd
 	void dot_product(Matrix<tsvd_float>& b_k1, Matrix<tsvd_float>& b_k, float* eigen_value_estimate, DeviceContext& context);
 	void dot_product(Matrix<tsvd_double>& b_k1, Matrix<tsvd_double>& b_k, double* eigen_value_estimate, DeviceContext& context);
 
+	void max_index_per_column(Matrix<tsvd_float>& A, std::vector<int>& result_array, DeviceContext& context);
+	void max_index_per_column(Matrix<tsvd_double>& A, std::vector<int>& result_array, DeviceContext& context);
+
 	//----------------------------------------------------------------------------------------------------------------------------------------------------------------------
 	//Stricly floating point operations that are not used
 

--- a/src/gpu/pca/pca.cu
+++ b/src/gpu/pca/pca.cu
@@ -19,7 +19,7 @@ namespace pca
 	 * @param _explained_variance_ratio
 	 * @param _param
 	 */
-	void pca_float(const float *_X, float *_Q, float *_w, float *_U, float *_explained_variance, float *_explained_variance_ratio, float *_mean, params _param) {
+	void pca_float(const float *_X, float *_Q, float *_w, float *_U, float* _X_transformed, float *_explained_variance, float *_explained_variance_ratio, float *_mean, params _param) {
 		try {
 
 			tsvd::safe_cuda(cudaSetDevice(_param.gpu_id));
@@ -50,7 +50,7 @@ namespace pca
 
 			tsvd::params svd_param = {_param.X_n, _param.X_m, _param.k, _param.algorithm, _param.n_iter, _param.random_state, _param.tol, _param.verbose, _param.gpu_id, _param.whiten};
 
-			tsvd::truncated_svd_matrix(XCentered, _Q, _w, _U, _explained_variance, _explained_variance_ratio, svd_param);
+			tsvd::truncated_svd_matrix(XCentered, _Q, _w, _U, _X_transformed, _explained_variance, _explained_variance_ratio, svd_param);
 
 		} catch (const std::exception &e) {
 			std::cerr << "pca error: " << e.what() << "\n";
@@ -73,7 +73,7 @@ namespace pca
 	 * @param _explained_variance_ratio
 	 * @param _param
 	 */
-	void pca_double(const double *_X, double *_Q, double *_w, double *_U, double *_explained_variance, double *_explained_variance_ratio, double *_mean, params _param) {
+	void pca_double(const double *_X, double *_Q, double *_w, double *_U, double* _X_transformed, double *_explained_variance, double *_explained_variance_ratio, double *_mean, params _param) {
 		try {
 
 			tsvd::safe_cuda(cudaSetDevice(_param.gpu_id));
@@ -104,7 +104,7 @@ namespace pca
 
 			tsvd::params svd_param = {_param.X_n, _param.X_m, _param.k, _param.algorithm, _param.n_iter, _param.random_state, _param.tol, _param.verbose, _param.gpu_id, _param.whiten};
 
-			tsvd::truncated_svd_matrix(XCentered, _Q, _w, _U, _explained_variance, _explained_variance_ratio, svd_param);
+			tsvd::truncated_svd_matrix(XCentered, _Q, _w, _U, _X_transformed, _explained_variance, _explained_variance_ratio, svd_param);
 
 		} catch (const std::exception &e) {
 			std::cerr << "pca error: " << e.what() << "\n";

--- a/src/gpu/tsvd/tsvd.cu
+++ b/src/gpu/tsvd/tsvd.cu
@@ -147,10 +147,9 @@ namespace tsvd
 		auto d_u = U.data();
 		auto d_u_abs = U_abs.data();
 		auto counting = thrust::make_counting_iterator <int>(0);
-		thrust::for_each(counting, counting+U_abs.size(), [=]__device__(int idx){
-			float abs_val = std::abs(d_u[idx]);
-			d_u_abs[idx] = abs_val;
-		} );
+		thrust::transform(d_u.dptr(), d_u.dptr() + d_u.size(), d_u_abs.dptr(), [=]__device__(T val){
+            return abs(val);
+        });
 	}
 
 	/**

--- a/src/gpu/tsvd/tsvd.cu
+++ b/src/gpu/tsvd/tsvd.cu
@@ -237,10 +237,8 @@ namespace tsvd
     	   Adjusts the columns of u and the rows of v such that the loadings in the
     	   columns in u that are largest in absolute value are always positive.
 		 */
-		Matrix<T>U_abs(U.rows(), U.columns());
-		get_abs(U, U_abs, context);
-		std::vector<int> result_array(U_abs.columns());
-		max_index_per_column(U_abs, result_array, context);
+		std::vector<int> result_array(U.columns());
+		max_index_per_column(U, result_array, context);
 		Matrix<T>Signs(1, _param.k);
 		thrust::device_vector<int> d_results = result_array;
 		auto d_U = U.data();

--- a/src/gpu/tsvd/tsvd.cu
+++ b/src/gpu/tsvd/tsvd.cu
@@ -142,12 +142,7 @@ namespace tsvd
 	 */
 	template<typename T>
 	void get_abs(const Matrix<T> &U, Matrix<T> &U_abs, DeviceContext &context){
-		auto n = U.columns();
-		auto m = U.rows();
-		auto d_u = U.data();
-		auto d_u_abs = U_abs.data();
-		auto counting = thrust::make_counting_iterator <int>(0);
-		thrust::transform(d_u.dptr(), d_u.dptr() + d_u.size(), d_u_abs.dptr(), [=]__device__(T val){
+		thrust::transform(U.dptr(), U.dptr() + U.size(), U_abs.dptr(), [=]__device__(T val){
             return abs(val);
         });
 	}

--- a/src/include/solver/pca.h
+++ b/src/include/solver/pca.h
@@ -32,7 +32,7 @@ typedef struct params {
  * \param 		  	_param
  */
 
-pca_export void pca_float(const float *_X, float *_Q, float *_w, float *_U, float *_explained_variance, float *_explained_variance_ratio, float *_mean, params _param);
-pca_export void pca_double(const double *_X, double *_Q, double *_w, double *_U, double *_explained_variance, double *_explained_variance_ratio, double *_mean, params _param);
+pca_export void pca_float(const float *_X, float *_Q, float *_w, float *_U, float* _X_transformed, float *_explained_variance, float *_explained_variance_ratio, float *_mean, params _param);
+pca_export void pca_double(const double *_X, double *_Q, double *_w, double *_U, double* _X_transformed, double *_explained_variance, double *_explained_variance_ratio, double *_mean, params _param);
 
 }

--- a/src/include/solver/tsvd.h
+++ b/src/include/solver/tsvd.h
@@ -37,16 +37,16 @@ typedef struct params {
  * \param 		  	_param
  */
 
-tsvd_export void truncated_svd_float(const float *_X, float *_Q, float *_w, float *_U, float *_explained_variance, float *_explained_variance_ratio, params _param);
-tsvd_export void truncated_svd_double(const double *_X, double *_Q, double *_w, double *_U, double *_explained_variance, double *_explained_variance_ratio, params _param);
+tsvd_export void truncated_svd_float(const float *_X, float *_Q, float *_w, float *_U, float *_X_transformed, float *_explained_variance, float *_explained_variance_ratio, params _param);
+tsvd_export void truncated_svd_double(const double *_X, double *_Q, double *_w, double *_U, double *_X_transformed, double *_explained_variance, double *_explained_variance_ratio, params _param);
 
 template<typename T, typename S>
-void cusolver_tsvd(Matrix<T> &X, S _Q, S _w, S _U, S _explained_variance, S _explained_variance_ratio, params _param);
+void cusolver_tsvd(Matrix<T> &X, S _Q, S _w, S _U, S _X_transformed, S _explained_variance, S _explained_variance_ratio, params _param);
 
 template<typename T, typename S>
-void power_tsvd(Matrix<T> &X, S _Q, S _w, S _U, S _explained_variance, S _explained_variance_ratio, params _param);
+void power_tsvd(Matrix<T> &X, S _Q, S _w, S _U, S _X_transformed, S _explained_variance, S _explained_variance_ratio, params _param);
 
 template<typename T, typename S>
-tsvd_export void truncated_svd_matrix(Matrix<T> &X, S _Q, S _w, S _U, S _explained_variance, S _explained_variance_ratio, params _param);
+tsvd_export void truncated_svd_matrix(Matrix<T> &X, S _Q, S _w, S _U, S _X_transformed, S _explained_variance, S _explained_variance_ratio, params _param);
 
 }

--- a/src/interface_py/h2o4gpu/solvers/pca.py
+++ b/src/interface_py/h2o4gpu/solvers/pca.py
@@ -95,7 +95,7 @@ class PCAH2O(TruncatedSVDH2O):
         explained_variance = np.empty(self.n_components, dtype=matrix_type)
         explained_variance_ratio = np.empty(self.n_components, dtype=matrix_type)
         mean = np.empty(X.shape[1], dtype=matrix_type)
-        X_transformed = np.empty((X.shape[0], self.n_components), dtype=matrix_type)
+        X_transformed = np.empty((U.shape[0], self.n_components), dtype=matrix_type)
 
         lib = self._load_lib()
 

--- a/src/interface_py/h2o4gpu/solvers/pca.py
+++ b/src/interface_py/h2o4gpu/solvers/pca.py
@@ -95,6 +95,7 @@ class PCAH2O(TruncatedSVDH2O):
         explained_variance = np.empty(self.n_components, dtype=matrix_type)
         explained_variance_ratio = np.empty(self.n_components, dtype=matrix_type)
         mean = np.empty(X.shape[1], dtype=matrix_type)
+        X_transformed = np.empty((X.shape[0], self.n_components), dtype=matrix_type)
 
         lib = self._load_lib()
 
@@ -111,9 +112,9 @@ class PCAH2O(TruncatedSVDH2O):
         param.whiten = self.whiten
 
         if self.double_precision == 1:
-            lib.pca_double(X, Q, w, U, explained_variance, explained_variance_ratio, mean, param)
+            lib.pca_double(X, Q, w, U, X_transformed, explained_variance, explained_variance_ratio, mean, param)
         else:
-            lib.pca_float(X, Q, w, U, explained_variance, explained_variance_ratio, mean, param)
+            lib.pca_float(X, Q, w, U, X_transformed, explained_variance, explained_variance_ratio, mean, param)
 
         self._w = w
         self._U, self._Q = svd_flip(U, Q)  # TODO Port to cuda?
@@ -140,7 +141,6 @@ class PCAH2O(TruncatedSVDH2O):
         else:
             self.noise_variance_ = 0.
 
-        X_transformed = U * w
         return X_transformed
 
     def _check_double(self, data, convert=True):

--- a/src/interface_py/h2o4gpu/solvers/truncated_svd.py
+++ b/src/interface_py/h2o4gpu/solvers/truncated_svd.py
@@ -111,7 +111,7 @@ class TruncatedSVDH2O(object):
         explained_variance = np.empty(self.n_components, dtype=matrix_type)
         explained_variance_ratio = np.empty(self.n_components,
                                             dtype=matrix_type)
-        X_transformed = np.empty((X.shape[0], self.n_components), dtype=matrix_type)
+        X_transformed = np.empty((U.shape[0], self.n_components), dtype=matrix_type)
 
         lib = self._load_lib()
 

--- a/src/interface_py/h2o4gpu/solvers/truncated_svd.py
+++ b/src/interface_py/h2o4gpu/solvers/truncated_svd.py
@@ -146,7 +146,8 @@ class TruncatedSVDH2O(object):
 
         self._w = w
         self._X = X
-        self._U, self._Q = svd_flip(U, Q)
+        self._U = U
+        self._Q = Q
         self.explained_variance = explained_variance
         self.explained_variance_ratio = explained_variance_ratio
         return X_transformed

--- a/src/interface_py/h2o4gpu/solvers/truncated_svd.py
+++ b/src/interface_py/h2o4gpu/solvers/truncated_svd.py
@@ -8,7 +8,6 @@ from __future__ import print_function
 import sys
 import numpy as np
 from ..solvers.utils import _setter
-from ..utils.extmath import svd_flip
 
 class TruncatedSVDH2O(object):
     """Dimensionality reduction using truncated SVD for GPUs

--- a/src/interface_py/h2o4gpu/solvers/truncated_svd.py
+++ b/src/interface_py/h2o4gpu/solvers/truncated_svd.py
@@ -111,6 +111,7 @@ class TruncatedSVDH2O(object):
         explained_variance = np.empty(self.n_components, dtype=matrix_type)
         explained_variance_ratio = np.empty(self.n_components,
                                             dtype=matrix_type)
+        X_transformed = np.empty((X.shape[0], self.n_components), dtype=matrix_type)
 
         lib = self._load_lib()
 
@@ -139,14 +140,13 @@ class TruncatedSVDH2O(object):
                              "but got`" + str(self.n_iter))
 
         if self.double_precision == 1:
-            lib.truncated_svd_double(X, Q, w, U, explained_variance, explained_variance_ratio, param)
+            lib.truncated_svd_double(X, Q, w, U, X_transformed, explained_variance, explained_variance_ratio, param)
         else:
-            lib.truncated_svd_float(X, Q, w, U, explained_variance, explained_variance_ratio, param)
+            lib.truncated_svd_float(X, Q, w, U, X_transformed, explained_variance, explained_variance_ratio, param)
 
         self._w = w
         self._X = X
         self._U, self._Q = svd_flip(U, Q)
-        X_transformed = self._U * self._w
         self.explained_variance = explained_variance
         self.explained_variance_ratio = explained_variance_ratio
         return X_transformed

--- a/src/swig/solver/pca.i
+++ b/src/swig/solver/pca.i
@@ -6,11 +6,11 @@
 %rename("params_pca") pca::params;
 
 %apply (double *IN_FARRAY2) {double *_X};
-%apply (double *INPLACE_FARRAY2) {double *_Q, double *_U, double *_mean};
+%apply (double *INPLACE_FARRAY2) {double *_Q, double *_U, double *_X_transformed, double *_mean};
 %apply (double *INPLACE_ARRAY1) {double *_w, double *_mean, double *_explained_variance, double *_explained_variance_ratio};
 
 %apply (float *IN_FARRAY2) {float *_X};
-%apply (float *INPLACE_FARRAY2) {float *_Q, float *_U, float *_mean};
+%apply (float *INPLACE_FARRAY2) {float *_Q, float *_U, float *_X_transformed, float *_mean};
 %apply (float *INPLACE_ARRAY1) {float *_w, float *_mean, float *_explained_variance, float *_explained_variance_ratio};
 
 %include "../../include/solver/pca.h"

--- a/src/swig/solver/tsvd.i
+++ b/src/swig/solver/tsvd.i
@@ -6,11 +6,11 @@
 %rename("params_tsvd") tsvd::params;
 
 %apply (float *IN_FARRAY2) {float *_X};
-%apply (float *INPLACE_FARRAY2) {float *_Q, float *_U};
+%apply (float *INPLACE_FARRAY2) {float *_Q, float *_U, float *_X_transformed};
 %apply (float *INPLACE_ARRAY1) {float *_w, float *_explained_variance, float *_explained_variance_ratio};
 
 %apply (double *IN_FARRAY2) {double *_X};
-%apply (double *INPLACE_FARRAY2) {double *_Q, double *_U};
+%apply (double *INPLACE_FARRAY2) {double *_Q, double *_U, double *_X_transformed};
 %apply (double *INPLACE_ARRAY1) {double *_w, double *_explained_variance, double *_explained_variance_ratio};
 
 %include "../../include/solver/tsvd.h"

--- a/tests_open/svd/test_tsvd_x_transformed.py
+++ b/tests_open/svd/test_tsvd_x_transformed.py
@@ -24,14 +24,13 @@ def func(m=5000, n=10, k=9, convert_to_float32 = False):
     h2o4gpu_tsvd_sklearn_wrapper = TruncatedSVDH2O(n_components=k, tol = 1e-50, n_iter=2000, random_state=42, verbose=True)
     h2o4gpu_tsvd_sklearn_wrapper.fit(X)
     X_transformed = h2o4gpu_tsvd_sklearn_wrapper.fit_transform(X)
-    #X_transformed = h2o4gpu_tsvd_sklearn_wrapper._U * h2o4gpu_tsvd_sklearn_wrapper._w
     print("\n")
     print("Sklearn run")
     # Exact scikit impl
     sklearn_tsvd = sklearnsvd(n_components=k, random_state=42)
     sklearn_tsvd.fit(X)
     X_transformed_sklearn = sklearn_tsvd.fit_transform(X)
-    #assert np.allclose(X_transformed, X_transformed_sklearn, atol=2.1)
+    assert np.allclose(X_transformed, X_transformed_sklearn, atol=2.1)
 
 def test_tsvd_error_k2_double(): func(n=5, k=2)
 def test_tsvd_error_k2_float32(): func(n=5, k=2, convert_to_float32=True)

--- a/tests_open/svd/test_tsvd_x_transformed.py
+++ b/tests_open/svd/test_tsvd_x_transformed.py
@@ -1,0 +1,37 @@
+import numpy as np
+import sys
+import logging
+from h2o4gpu.decomposition import TruncatedSVDSklearn as sklearnsvd
+from h2o4gpu.solvers import TruncatedSVDH2O
+
+print(sys.path)
+
+logging.basicConfig(level=logging.DEBUG)
+
+def func(m=5000, n=10, k=9, convert_to_float32 = False):
+    np.random.seed(1234)
+
+    X = np.random.rand(m, n)
+    if convert_to_float32:
+        X = X.astype(np.float32)
+
+    print("SVD on " + str(X.shape[0]) + " by " + str(X.shape[1]) + " matrix")
+    print("Original X Matrix")
+    print(X)
+
+    print("\n")
+    print("H2O4GPU run")
+    h2o4gpu_tsvd_sklearn_wrapper = TruncatedSVDH2O(n_components=k, tol = 1e-50, n_iter=2000, random_state=42, verbose=True)
+    h2o4gpu_tsvd_sklearn_wrapper.fit(X)
+    X_transformed = h2o4gpu_tsvd_sklearn_wrapper.fit_transform(X)
+    #X_transformed = h2o4gpu_tsvd_sklearn_wrapper._U * h2o4gpu_tsvd_sklearn_wrapper._w
+    print("\n")
+    print("Sklearn run")
+    # Exact scikit impl
+    sklearn_tsvd = sklearnsvd(n_components=k, random_state=42)
+    sklearn_tsvd.fit(X)
+    X_transformed_sklearn = sklearn_tsvd.fit_transform(X)
+    #assert np.allclose(X_transformed, X_transformed_sklearn, atol=2.1)
+
+def test_tsvd_error_k2_double(): func(n=5, k=2)
+def test_tsvd_error_k2_float32(): func(n=5, k=2, convert_to_float32=True)


### PR DESCRIPTION
* Resolves #444
* Add svd sign correction (https://github.com/scikit-learn/scikit-learn/blob/master/sklearn/utils/extmath.py#L499) to tsvd backend, which will calculate the transformed `X` matrix on the device instead of the host.
* Test added but special handling is needed for power/float32 (might be due to iterative nature of power (approximate solution) and float32 precision)