### PR TITLE
Fail the build on compilation errors.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -19,6 +19,7 @@ OPTION(DEV_BUILD  "Dev build" OFF)
 SET(CMAKE_CXX_STANDARD 11)
 SET(CMAKE_CXX_STANDARD_REQUIRED ON)
 SET(CMAKE_POSITION_INDEPENDENT_CODE ON)
+set(CMAKE_CXX_FLAGS  "${CMAKE_CXX_FLAGS} -w")
 
 # PythonLibs' PYTHON_INCLUDE_PATH doesn't take into account virtualenv etc.
 # Open to suggestions how to do this better.
@@ -70,7 +71,7 @@ TARGET_LINK_LIBRARIES(cpuh2o4gpu ${BLAS_LIBRARIES})
 #============= BUILD CPU LIBRARY
 
 #============= SWIG
-SET(CMAKE_SWIG_FLAGS "")
+SET(CMAKE_SWIG_FLAGS -Werror)
 #============= SWIG
 
 #============= CPU SWIG
@@ -114,7 +115,7 @@ if(USE_CUDA)
 
         SET(GENCODE_FLAGS "")
         FORMAT_GENCODE_FLAGS("${GPU_COMPUTE_VER}" GENCODE_FLAGS)
-        SET(CUDA_NVCC_FLAGS "${CUDA_NVCC_FLAGS};-Xcompiler -fPIC; -std=c++11;--expt-extended-lambda;--expt-relaxed-constexpr;${GENCODE_FLAGS};-lineinfo;")
+        SET(CUDA_NVCC_FLAGS "${CUDA_NVCC_FLAGS};-Xcompiler -fPIC; -std=c++11;--expt-extended-lambda;--expt-relaxed-constexpr;${GENCODE_FLAGS};-lineinfo; -w;")
 
         FILE(GLOB_RECURSE GPU_SOURCES
                 src/*.cu

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -19,7 +19,7 @@ OPTION(DEV_BUILD  "Dev build" OFF)
 SET(CMAKE_CXX_STANDARD 11)
 SET(CMAKE_CXX_STANDARD_REQUIRED ON)
 SET(CMAKE_POSITION_INDEPENDENT_CODE ON)
-set(CMAKE_CXX_FLAGS  "${CMAKE_CXX_FLAGS} -w")
+SET(CMAKE_CXX_FLAGS  "${CMAKE_CXX_FLAGS} -w")
 
 # PythonLibs' PYTHON_INCLUDE_PATH doesn't take into account virtualenv etc.
 # Open to suggestions how to do this better.

--- a/Makefile
+++ b/Makefile
@@ -119,11 +119,11 @@ update_submodule:
 	echo ADD UPDATE SUBMODULE HERE
 
 cpp:
-	mkdir -p build; \
-	cd build; \
-	cmake -DDEV_BUILD=${DEV_BUILD} -DNVML_LIB=$(NVML_LIB)/libnvidia-ml.so ../; \
-	make -j; \
-	cp _ch2o4gpu_*pu.so ../src/interface_c/; \
+	mkdir -p build && \
+	cd build && \
+	cmake -DDEV_BUILD=${DEV_BUILD} -DNVML_LIB=$(NVML_LIB)/libnvidia-ml.so ../ && \
+	make -j && \
+	cp _ch2o4gpu_*pu.so ../src/interface_c/ && \
 	cp ch2o4gpu_*pu.py ../src/interface_py/h2o4gpu/libs;
 
 py: apply-sklearn_simple build/VERSION.txt

--- a/requirements_buildonly.txt
+++ b/requirements_buildonly.txt
@@ -36,3 +36,4 @@ psutil==5.4.5
 awscli==1.15.6
 # for pycharm
 matplotlib==2.0.2
+llvmlite==0.20.0

--- a/src/include/solver/pca.h
+++ b/src/include/solver/pca.h
@@ -12,7 +12,7 @@ typedef struct params {
   int X_n;
   int X_m;
   int k;
-  const char *algorithm;
+  char *algorithm;
   int n_iter;
   int random_state;
   float tol;

--- a/src/include/solver/tsvd.h
+++ b/src/include/solver/tsvd.h
@@ -17,7 +17,7 @@ typedef struct params {
   int X_n;
   int X_m;
   int k;
-  const char *algorithm;
+  char *algorithm;
   int n_iter;
   int random_state;
   float tol;


### PR DESCRIPTION
* Fails the build when compilation errors. Until now, even if `cpp` (`.so` compilation) failed, subsequent targets (for example `py`) would run.

* Fails compilation when SWIG cannot find type mappings - this usually happens when we have a typo in the interface file etc. and normally shows only as a warning in SWIG - can cause hard to find bugs in the future.

* Removed `const` from `const char *` because the compiler was saying it's a warning and can cause issues - @navdeep-G do we really want it to be `const`? I can put it back and probably suppress that warning

* Put `-w` which suppresses all warnings durning gcc/nvcc compilation as it was cluttering the logs making it hard to find actual errors. If anyone is actually looking at those warnings all the time (but seeing no one is fixing them I assume no?) and needs them I can remove it.

* Added `llvmlite` in version 0.20.0, looks like we need it as a transitive dep (for scikit?) and the newest version 0.23.0 requires LLVM6 which is not great for us (especially for centos build but was also failing on ubuntu for me).