### PR TITLE
Ensure namespaces are organized and named properly

### DIFF
--- a/src/gpu/data/matrix.cu
+++ b/src/gpu/data/matrix.cu
@@ -5,6 +5,9 @@
 
 namespace tsvd
 {
+	using namespace device;
+	using namespace h2o4gpu;
+
 	void max_index_per_column(Matrix<tsvd_float>& A, std::vector<int>& result_array, DeviceContext& context){
 
 		int result;

--- a/src/gpu/data/matrix.cu
+++ b/src/gpu/data/matrix.cu
@@ -7,7 +7,7 @@ namespace matrix
 {
 	using namespace h2o4gpu;
 
-	void max_index_per_column(Matrix<matrix_float>& A, std::vector<int>& result_array, device::DeviceContext& context){
+	void max_index_per_column(Matrix<float>& A, std::vector<int>& result_array, device::DeviceContext& context){
 
 		int result;
 		for (int i=0; i<A.columns(); i++) {
@@ -16,7 +16,7 @@ namespace matrix
 		}
 	}
 
-	void max_index_per_column(Matrix<matrix_double>& A, std::vector<int>& result_array, device::DeviceContext& context){
+	void max_index_per_column(Matrix<double>& A, std::vector<int>& result_array, device::DeviceContext& context){
 
 		int result;
 		for (int i=0; i<A.columns(); i++) {
@@ -68,7 +68,7 @@ namespace matrix
 		M.transform([=]__device__ (float val){return val / std::sqrt(M_inner);});
 	}
 
-	void multiply_diag(const Matrix<matrix_float>& A, const Matrix<matrix_float>& B, Matrix<matrix_float>& C, device::DeviceContext& context, bool left_diag)
+	void multiply_diag(const Matrix<float>& A, const Matrix<float>& B, Matrix<float>& C, device::DeviceContext& context, bool left_diag)
 	{
 		cublasSideMode_t mode = left_diag ? CUBLAS_SIDE_LEFT : CUBLAS_SIDE_RIGHT;
 
@@ -81,7 +81,7 @@ namespace matrix
 		safe_cublas(cublasSdgmm(context.cublas_handle, mode, m, n, A.data(), lda, B.data(), incx, C.data(), ldc));
 	}
 
-	void multiply_diag(const Matrix<matrix_double>& A, const Matrix<matrix_double>& B, Matrix<matrix_double>& C, device::DeviceContext& context, bool left_diag)
+	void multiply_diag(const Matrix<double>& A, const Matrix<double>& B, Matrix<double>& C, device::DeviceContext& context, bool left_diag)
 	{
 		cublasSideMode_t mode = left_diag ? CUBLAS_SIDE_LEFT : CUBLAS_SIDE_RIGHT;
 
@@ -94,12 +94,12 @@ namespace matrix
 		safe_cublas(cublasDdgmm(context.cublas_handle, mode, m, n, A.data(), lda, B.data(), incx, C.data(), ldc));
 	}
 
-	void multiply(const Matrix<matrix_float>& A, const Matrix<matrix_float>& B, Matrix<matrix_float>& C, device::DeviceContext& context, bool transpose_a, bool transpose_b, matrix_float alpha)
+	void multiply(const Matrix<float>& A, const Matrix<float>& B, Matrix<float>& C, device::DeviceContext& context, bool transpose_a, bool transpose_b, float alpha)
 	{
 		cublasOperation_t op_a = transpose_a ? CUBLAS_OP_T : CUBLAS_OP_N;
 		cublasOperation_t op_b = transpose_b ? CUBLAS_OP_T : CUBLAS_OP_N;
 
-		const matrix_float beta = 0;
+		const float beta = 0;
 
 		int m = C.rows();
 		int n = C.columns();
@@ -111,12 +111,12 @@ namespace matrix
 		safe_cublas(cublasSgemm(context.cublas_handle, op_a, op_b, m, n, k, &alpha, A.data(), lda, B.data(), ldb, &beta, C.data(), ldc));
 	}
 
-	void multiply(const Matrix<matrix_double>& A, const Matrix<matrix_double>& B, Matrix<matrix_double>& C, device::DeviceContext& context, bool transpose_a, bool transpose_b, matrix_double alpha)
+	void multiply(const Matrix<double>& A, const Matrix<double>& B, Matrix<double>& C, device::DeviceContext& context, bool transpose_a, bool transpose_b, double alpha)
 	{
 		cublasOperation_t op_a = transpose_a ? CUBLAS_OP_T : CUBLAS_OP_N;
 		cublasOperation_t op_b = transpose_b ? CUBLAS_OP_T : CUBLAS_OP_N;
 
-		const matrix_double beta = 0;
+		const double beta = 0;
 
 		int m = C.rows();
 		int n = C.columns();
@@ -128,32 +128,32 @@ namespace matrix
 		safe_cublas(cublasDgemm(context.cublas_handle, op_a, op_b, m, n, k, &alpha, A.data(), lda, B.data(), ldb, &beta, C.data(), ldc));
 	}
 
-	void transpose(const Matrix<matrix_float>& A, Matrix<matrix_float>& B, device::DeviceContext& context)
+	void transpose(const Matrix<float>& A, Matrix<float>& B, device::DeviceContext& context)
 	{
 		h2o4gpu_check(A.rows() == B.columns()&&A.columns() == B.rows(), "Transpose dimensions incorrect");
-		const matrix_float alpha = 1.0f;
-		const matrix_float beta = 0.0f;
+		const float alpha = 1.0f;
+		const float beta = 0.0f;
 		safe_cublas(cublasSgeam(context.cublas_handle, CUBLAS_OP_T, CUBLAS_OP_N, B.rows(), B.columns(), &alpha, A.data(), A.rows(), &beta, NULL, B.rows(), B.data(), B.rows()));
 	}
 
-	void transpose(const Matrix<matrix_double>& A, Matrix<matrix_double>& B, device::DeviceContext& context)
+	void transpose(const Matrix<double>& A, Matrix<double>& B, device::DeviceContext& context)
 	{
 		h2o4gpu_check(A.rows() == B.columns()&&A.columns() == B.rows(), "Transpose dimensions incorrect");
-		const matrix_double alpha = 1.0f;
-		const matrix_double beta = 0.0f;
+		const double alpha = 1.0f;
+		const double beta = 0.0f;
 		safe_cublas(cublasDgeam(context.cublas_handle, CUBLAS_OP_T, CUBLAS_OP_N, B.rows(), B.columns(), &alpha, A.data(), A.rows(), &beta, NULL, B.rows(), B.data(), B.rows()));
 	}
 
-	void normalize_columns(Matrix<matrix_float>& M, Matrix<matrix_float>& M_temp, Matrix<matrix_float>& column_length, const Matrix<matrix_float>& ones, device::DeviceContext& context)
+	void normalize_columns(Matrix<float>& M, Matrix<float>& M_temp, Matrix<float>& column_length, const Matrix<float>& ones, device::DeviceContext& context)
 	{
 		thrust::transform(M.dptr(), M.dptr() + M.size(), M_temp.dptr(), sqr_op());
 		auto d_column_length = column_length.data();
 		auto d_ones = ones.data();
-		const matrix_float alpha = 1.0f;
-		const matrix_float beta = 0.0f;
+		const float alpha = 1.0f;
+		const float beta = 0.0f;
 		safe_cublas(cublasSgemv(context.cublas_handle, CUBLAS_OP_T, M.rows(), M.columns(), &alpha, M_temp.data(), M.rows(), d_ones, 1, &beta, d_column_length, 1));
 
-		thrust::transform(column_length.dptr(), column_length.dptr() + column_length.size(), column_length.dptr(), [=]__device__(matrix_float val)
+		thrust::transform(column_length.dptr(), column_length.dptr() + column_length.size(), column_length.dptr(), [=]__device__(float val)
 		                  {
 							  if (val == 0.0)
 							  {
@@ -166,16 +166,16 @@ namespace matrix
 		safe_cublas(cublasSdgmm(context.cublas_handle, CUBLAS_SIDE_RIGHT, M.rows(), M.columns(), M.data(), M.rows(), d_column_length, 1, M.data(), M.rows()));
 	}
 
-	void normalize_columns(Matrix<matrix_double>& M, Matrix<matrix_double>& M_temp, Matrix<matrix_double>& column_length, const Matrix<matrix_double>& ones, device::DeviceContext& context)
+	void normalize_columns(Matrix<double>& M, Matrix<double>& M_temp, Matrix<double>& column_length, const Matrix<double>& ones, device::DeviceContext& context)
 	{
 		thrust::transform(M.dptr(), M.dptr() + M.size(), M_temp.dptr(), sqr_op());
 		auto d_column_length = column_length.data();
 		auto d_ones = ones.data();
-		const matrix_double alpha = 1.0f;
-		const matrix_double beta = 0.0f;
+		const double alpha = 1.0f;
+		const double beta = 0.0f;
 		safe_cublas(cublasDgemv(context.cublas_handle, CUBLAS_OP_T, M.rows(), M.columns(), &alpha, M_temp.data(), M.rows(), d_ones, 1, &beta, d_column_length, 1));
 
-		thrust::transform(column_length.dptr(), column_length.dptr() + column_length.size(), column_length.dptr(), [=]__device__(matrix_double val)
+		thrust::transform(column_length.dptr(), column_length.dptr() + column_length.size(), column_length.dptr(), [=]__device__(double val)
 		                  {
 							  if (val == 0.0)
 							  {
@@ -188,7 +188,7 @@ namespace matrix
 		safe_cublas(cublasDdgmm(context.cublas_handle, CUBLAS_SIDE_RIGHT, M.rows(), M.columns(), M.data(), M.rows(), d_column_length, 1, M.data(), M.rows()));
 	}
 
-	void normalize_columns(Matrix<matrix_float>& M, device::DeviceContext& context)
+	void normalize_columns(Matrix<float>& M, device::DeviceContext& context)
 	{
 		Matrix<float> M_temp(M.rows(), M.columns());
 		Matrix<float> columns_length(1, M.columns());
@@ -197,7 +197,7 @@ namespace matrix
 		normalize_columns(M, M_temp, columns_length, ones, context);
 	}
 
-	void normalize_columns(Matrix<matrix_double>& M, device::DeviceContext& context)
+	void normalize_columns(Matrix<double>& M, device::DeviceContext& context)
 	{
 		Matrix<double> M_temp(M.rows(), M.columns());
 		Matrix<double> columns_length(1, M.columns());
@@ -206,31 +206,31 @@ namespace matrix
 		normalize_columns(M, M_temp, columns_length, ones, context);
 	}
 
-	void normalize_vector_cublas(Matrix<matrix_float>& M, device::DeviceContext& context){
+	void normalize_vector_cublas(Matrix<float>& M, device::DeviceContext& context){
         float norm2 = 0.0;
         safe_cublas(cublasSnrm2(context.cublas_handle, M.rows(), M.data(), 1.0, &norm2));
         M.transform([=]__device__ (float val){return val * (1/norm2);});
     }
 
-	void normalize_vector_cublas(Matrix<matrix_double>& M, device::DeviceContext& context){
+	void normalize_vector_cublas(Matrix<double>& M, device::DeviceContext& context){
         double norm2 = 0.0;
         safe_cublas(cublasDnrm2(context.cublas_handle, M.rows(), M.data(), 1.0, &norm2));
         M.transform([=]__device__ (float val){return val * (1/norm2);});
     }
 
-	void residual(const Matrix<matrix_float>& X, const Matrix<matrix_float>& D, const Matrix<matrix_float>& S, Matrix<matrix_float>& R, device::DeviceContext& context)
+	void residual(const Matrix<float>& X, const Matrix<float>& D, const Matrix<float>& S, Matrix<float>& R, device::DeviceContext& context)
 	{
 		multiply(D, S, R, context);
 		subtract(X, R, R, context);
 	}
 
-	void residual(const Matrix<matrix_double>& X, const Matrix<matrix_double>& D, const Matrix<matrix_double>& S, Matrix<matrix_double>& R, device::DeviceContext& context)
+	void residual(const Matrix<double>& X, const Matrix<double>& D, const Matrix<double>& S, Matrix<double>& R, device::DeviceContext& context)
 	{
 		multiply(D, S, R, context);
 		subtract(X, R, R, context);
 	}
 
-	void calculate_eigen_pairs_exact(const Matrix<matrix_float>& X, Matrix<matrix_float>& Q, Matrix<matrix_float>& w, device::DeviceContext& context)
+	void calculate_eigen_pairs_exact(const Matrix<float>& X, Matrix<float>& Q, Matrix<float>& w, device::DeviceContext& context)
 	{
 		h2o4gpu_check(X.rows() == X.columns(), "X must be a symmetric matrix");
 		h2o4gpu_check(X.rows() == Q.rows() && X.columns() == Q.columns(), "X and Q must have the same dimension");
@@ -252,7 +252,7 @@ namespace matrix
 		safe_cuda(cudaGetLastError());
 	}
 
-	void calculate_eigen_pairs_exact(const Matrix<matrix_double>& X, Matrix<matrix_double>& Q, Matrix<matrix_double>& w, device::DeviceContext& context)
+	void calculate_eigen_pairs_exact(const Matrix<double>& X, Matrix<double>& Q, Matrix<double>& w, device::DeviceContext& context)
 	{
 		h2o4gpu_check(X.rows() == X.columns(), "X must be a symmetric matrix");
 		h2o4gpu_check(X.rows() == Q.rows() && X.columns() == Q.columns(), "X and Q must have the same dimension");
@@ -274,36 +274,36 @@ namespace matrix
 		safe_cuda(cudaGetLastError());
 	}
 
-	void dot_product(Matrix<matrix_float>& b_k1, Matrix<matrix_float>& b_k, float* eigen_value_estimate, device::DeviceContext& context)
+	void dot_product(Matrix<float>& b_k1, Matrix<float>& b_k, float* eigen_value_estimate, device::DeviceContext& context)
 	{
 		safe_cublas(cublasSdot(context.cublas_handle, b_k1.rows(), b_k1.data(), 1.0, b_k.data(), 1.0, eigen_value_estimate));
 	}
 
-	void dot_product(Matrix<matrix_double>& b_k1, Matrix<matrix_double>& b_k, double* eigen_value_estimate, device::DeviceContext& context)
+	void dot_product(Matrix<double>& b_k1, Matrix<double>& b_k, double* eigen_value_estimate, device::DeviceContext& context)
 	{
 		safe_cublas(cublasDdot(context.cublas_handle, b_k1.rows(), b_k1.data(), 1.0, b_k.data(), 1.0, eigen_value_estimate));
 	}
 
 	//----------------------------------------------------------------------------------------------------------------------------------------------------------------------
 	//Stricly floating point operations that are not used
-	void linear_solve(const Matrix<matrix_float>& A, Matrix<matrix_float>& X, const Matrix<matrix_float>& B, device::DeviceContext& context)
+	void linear_solve(const Matrix<float>& A, Matrix<float>& X, const Matrix<float>& B, device::DeviceContext& context)
 	{
 		h2o4gpu_check(A.rows()>= A.columns(),"Linear solve requires m >= n");
 		h2o4gpu_check(X.rows()>= X.columns(),"Linear solve requires n >= k"); //TODO: is this restriction necessary?
 
-		Matrix<matrix_float> A_copy(A);
-		Matrix<matrix_float> B_copy(A.rows(), A.columns());
+		Matrix<float> A_copy(A);
+		Matrix<float> B_copy(A.rows(), A.columns());
 		thrust::copy(B.dptr(), B.dptr() + B.size(), B_copy.dptr());
 		thrust::fill(B_copy.dptr() + B.size(), B_copy.dptr() + B_copy.size(), 0.0f);
 
 		int work_size = 0;
 		safe_cusolver(cusolverDnSgeqrf_bufferSize(context.cusolver_handle, A_copy.rows(), A_copy.columns(), A_copy.data(), A_copy.rows(), &work_size));
 
-		thrust::device_vector<matrix_float> work(work_size);
-		matrix_float* d_work = thrust::raw_pointer_cast(work.data());
+		thrust::device_vector<float> work(work_size);
+		float* d_work = thrust::raw_pointer_cast(work.data());
 
-		thrust::device_vector<matrix_float> tau((std::min)(A.rows(), A.columns()));
-		matrix_float* d_tau = thrust::raw_pointer_cast(tau.data());
+		thrust::device_vector<float> tau((std::min)(A.rows(), A.columns()));
+		float* d_tau = thrust::raw_pointer_cast(tau.data());
 
 		thrust::device_vector<int> dev_info(1);
 		int* d_dev_info = thrust::raw_pointer_cast(dev_info.data());
@@ -315,8 +315,8 @@ namespace matrix
 		safe_cusolver(cusolverDnSormqr(context.cusolver_handle, CUBLAS_SIDE_LEFT, CUBLAS_OP_T, A.rows(), A.columns(), (std::min)(A.rows(), A.columns()), A_copy.data(), A.rows(), d_tau, B_copy.data(), A.rows(), d_work, work_size, d_dev_info));
 		h2o4gpu_check(dev_info[0] == 0, "ormqr unsuccessful");
 
-		Matrix<matrix_float> R(A.columns(), A.columns());
-		Matrix<matrix_float> QTB(A.columns(), B.columns());
+		Matrix<float> R(A.columns(), A.columns());
+		Matrix<float> QTB(A.columns(), B.columns());
 		auto counting = thrust::make_counting_iterator(0);
 		int n = R.columns();
 		int m = A.rows();
@@ -337,18 +337,18 @@ namespace matrix
 			                 }
 		                 });
 
-		const matrix_float alpha = 1.0f;
+		const float alpha = 1.0f;
 		safe_cublas(cublasStrsm(context.cublas_handle, CUBLAS_SIDE_LEFT, CUBLAS_FILL_MODE_UPPER, CUBLAS_OP_N, CUBLAS_DIAG_NON_UNIT, QTB.rows(), QTB.columns(), &alpha, R.data(), R.rows(), QTB.data(), QTB.rows()));
 
 		thrust::copy(QTB.dptr(), QTB.dptr() + QTB.size(), X.data());
 	}
 
-	void pseudoinverse(const Matrix<matrix_float>& A, Matrix<matrix_float>& pinvA, device::DeviceContext& context)
+	void pseudoinverse(const Matrix<float>& A, Matrix<float>& pinvA, device::DeviceContext& context)
 	{
 		h2o4gpu_check(A.rows() == pinvA.columns() && A.columns() == pinvA.rows(), "pseudoinverse dimensions incorrect");
 
 		//Add zero rows if m < n such that m >= n
-		Matrix<matrix_float> A_extended((std::max)(A.columns(), A.rows()), A.columns());
+		Matrix<float> A_extended((std::max)(A.columns(), A.rows()), A.columns());
 		auto counting = thrust::make_counting_iterator(0);
 		int A_column_size = A.rows();
 		int A_extended_column_size = A_extended.rows();
@@ -373,17 +373,17 @@ namespace matrix
 		int work_size = 0;
 		safe_cusolver(cusolverDnSgesvd_bufferSize(context.cusolver_handle, A_extended.rows(), A_extended.columns(), &work_size));
 
-		Matrix<matrix_float> work(work_size, 1);
+		Matrix<float> work(work_size, 1);
 
-		Matrix<matrix_float> S((std::min)(A_extended.rows(), A_extended.columns()), 1);
-		Matrix<matrix_float> U(A_extended.rows(), A_extended.rows());
-		Matrix<matrix_float> VT(A_extended.columns(), A_extended.columns());
+		Matrix<float> S((std::min)(A_extended.rows(), A_extended.columns()), 1);
+		Matrix<float> U(A_extended.rows(), A_extended.rows());
+		Matrix<float> VT(A_extended.columns(), A_extended.columns());
 		Matrix<int> dev_info(1, 1);
 
 		safe_cusolver (cusolverDnSgesvd(context.cusolver_handle, 'A', 'A', A_extended.rows(), A_extended.columns(), d_A_extended, A_extended.rows(), S.data(), U.data(), U.rows(), VT.data(), VT.rows(), work.data(), work_size, NULL, dev_info.data()));
 
-		matrix_float eps = 1e-5;
-		thrust::transform(S.dptr(), S.dptr() + S.size(), S.dptr(), [=]__device__(matrix_float val)
+		float eps = 1e-5;
+		thrust::transform(S.dptr(), S.dptr() + S.size(), S.dptr(), [=]__device__(float val)
 		                  {
 			                  if (abs(val) < eps)
 			                  {
@@ -395,41 +395,41 @@ namespace matrix
 			                  }
 		                  });
 
-		Matrix<matrix_float> UT(A_extended.rows(), A_extended.rows());
+		Matrix<float> UT(A_extended.rows(), A_extended.rows());
 
 		//Calculate transpose of U
-		const matrix_float alpha = 1.0;
-		const matrix_float beta = 0.0;
+		const float alpha = 1.0;
+		const float beta = 0.0;
 		safe_cublas(cublasSgeam(context.cublas_handle, CUBLAS_OP_T, CUBLAS_OP_N, UT.rows(), UT.columns(), &alpha, U.data(), UT.rows(), &beta,NULL, UT.rows(), UT.data(), UT.rows()));
 
 		safe_cublas(cublasSdgmm(context.cublas_handle, CUBLAS_SIDE_LEFT, UT.rows(), UT.columns(), UT.data(), UT.rows(), S.data(), 1, U.data(), U.rows()));
 
-		Matrix<matrix_float> pinvA_extended(A_extended.columns(), A_extended.rows());
+		Matrix<float> pinvA_extended(A_extended.columns(), A_extended.rows());
 		multiply(VT, U, pinvA_extended, context, true);
 
 		thrust::copy(pinvA_extended.dptr(), pinvA_extended.dptr() + pinvA.size(), pinvA.dptr());
 	}
 
-	void f_normalize(Matrix<matrix_float>& M, device::DeviceContext& context)
+	void f_normalize(Matrix<float>& M, device::DeviceContext& context)
 	{
-		Matrix<matrix_float> temp(M.rows(), M.columns());
+		Matrix<float> temp(M.rows(), M.columns());
 		thrust::transform(M.dptr(), M.dptr() + M.size(), temp.dptr(), sqr_op());
-		matrix_float sum = thrust::reduce(temp.dptr(), temp.dptr() + temp.size());
+		float sum = thrust::reduce(temp.dptr(), temp.dptr() + temp.size());
 		multiply(M, 1.0 / std::sqrt(sum), context);
 		thrust::transform(M.dptr(), M.dptr() + M.size(), temp.dptr(), sqr_op());
-		matrix_float final_sum = thrust::reduce(temp.dptr(), temp.dptr() + temp.size());
+		float final_sum = thrust::reduce(temp.dptr(), temp.dptr() + temp.size());
 		printf("f norm sum squares: %1.4f\n", final_sum);
 	}
 
-	void normalize_columns_cub(Matrix<matrix_float>& M, device::DeviceContext& context)
+	void normalize_columns_cub(Matrix<float>& M, device::DeviceContext& context)
 	{
 		//Create alias so device Lamba does not dereference this pointer
 		int m = M.rows();
 
-		thrust::device_vector<matrix_float> temp(M.size());
-		thrust::device_vector<matrix_float> length_squared(M.columns());
+		thrust::device_vector<float> temp(M.size());
+		thrust::device_vector<float> length_squared(M.columns());
 
-		thrust::transform(M.dptr(), M.dptr() + M.size(), temp.begin(), [=]__device__(matrix_float val)
+		thrust::transform(M.dptr(), M.dptr() + M.size(), temp.begin(), [=]__device__(float val)
 		                  {
 			                  return val * val;
 		                  });
@@ -462,7 +462,7 @@ namespace matrix
 		                  {
 			                  int col = idx / m;
 
-			                  matrix_float length_squared = d_length_squared[col];
+			                  float length_squared = d_length_squared[col];
 
 			                  if (length_squared > 0.0)
 			                  {

--- a/src/gpu/data/matrix.cu
+++ b/src/gpu/data/matrix.cu
@@ -5,10 +5,9 @@
 
 namespace tsvd
 {
-	using namespace device;
 	using namespace h2o4gpu;
 
-	void max_index_per_column(Matrix<tsvd_float>& A, std::vector<int>& result_array, DeviceContext& context){
+	void max_index_per_column(Matrix<tsvd_float>& A, std::vector<int>& result_array, device::DeviceContext& context){
 
 		int result;
 		for (int i=0; i<A.columns(); i++) {
@@ -17,7 +16,7 @@ namespace tsvd
 		}
 	}
 
-	void max_index_per_column(Matrix<tsvd_double>& A, std::vector<int>& result_array, DeviceContext& context){
+	void max_index_per_column(Matrix<tsvd_double>& A, std::vector<int>& result_array, device::DeviceContext& context){
 
 		int result;
 		for (int i=0; i<A.columns(); i++) {
@@ -27,7 +26,7 @@ namespace tsvd
 	}
 
 	template<typename T, typename U>
-	void multiply(Matrix<T>& A, const U a, DeviceContext& context)
+	void multiply(Matrix<T>& A, const U a, device::DeviceContext& context)
 	{
 		thrust::transform(A.dptr(), A.dptr() + A.size(), A.dptr(), [=]__device__ (U val)
 						  {
@@ -37,7 +36,7 @@ namespace tsvd
 	}
 
 	template<typename T>
-	void subtract(const Matrix<T>& A, const Matrix<T>& B, Matrix<T>& C, DeviceContext& context)
+	void subtract(const Matrix<T>& A, const Matrix<T>& B, Matrix<T>& C, device::DeviceContext& context)
 	{
 		auto counting = thrust::make_counting_iterator(0);
 		const T* d_A = A.data();
@@ -50,7 +49,7 @@ namespace tsvd
 	}
 
 	template<typename T>
-	void add(const Matrix<T>& A, const Matrix<T>& B, Matrix<T>& C, DeviceContext& context)
+	void add(const Matrix<T>& A, const Matrix<T>& B, Matrix<T>& C, device::DeviceContext& context)
 	{
 		auto counting = thrust::make_counting_iterator(0);
 		const T* d_A = A.data();
@@ -64,12 +63,12 @@ namespace tsvd
 
 
 	template<typename T>
-	void normalize_vector_thrust(Matrix<T>& M, DeviceContext& context){
+	void normalize_vector_thrust(Matrix<T>& M, device::DeviceContext& context){
 		float M_inner = thrust::inner_product(M.dptr(), M.dptr() + M.size(), M.dptr(), 0.0f); //Will allocate memory for every call to fxn.
 		M.transform([=]__device__ (float val){return val / std::sqrt(M_inner);});
 	}
 
-	void multiply_diag(const Matrix<tsvd_float>& A, const Matrix<tsvd_float>& B, Matrix<tsvd_float>& C, DeviceContext& context, bool left_diag)
+	void multiply_diag(const Matrix<tsvd_float>& A, const Matrix<tsvd_float>& B, Matrix<tsvd_float>& C, device::DeviceContext& context, bool left_diag)
 	{
 		cublasSideMode_t mode = left_diag ? CUBLAS_SIDE_LEFT : CUBLAS_SIDE_RIGHT;
 
@@ -82,7 +81,7 @@ namespace tsvd
 		safe_cublas(cublasSdgmm(context.cublas_handle, mode, m, n, A.data(), lda, B.data(), incx, C.data(), ldc));
 	}
 
-	void multiply_diag(const Matrix<tsvd_double>& A, const Matrix<tsvd_double>& B, Matrix<tsvd_double>& C, DeviceContext& context, bool left_diag)
+	void multiply_diag(const Matrix<tsvd_double>& A, const Matrix<tsvd_double>& B, Matrix<tsvd_double>& C, device::DeviceContext& context, bool left_diag)
 	{
 		cublasSideMode_t mode = left_diag ? CUBLAS_SIDE_LEFT : CUBLAS_SIDE_RIGHT;
 
@@ -95,7 +94,7 @@ namespace tsvd
 		safe_cublas(cublasDdgmm(context.cublas_handle, mode, m, n, A.data(), lda, B.data(), incx, C.data(), ldc));
 	}
 
-	void multiply(const Matrix<tsvd_float>& A, const Matrix<tsvd_float>& B, Matrix<tsvd_float>& C, DeviceContext& context, bool transpose_a, bool transpose_b, tsvd_float alpha)
+	void multiply(const Matrix<tsvd_float>& A, const Matrix<tsvd_float>& B, Matrix<tsvd_float>& C, device::DeviceContext& context, bool transpose_a, bool transpose_b, tsvd_float alpha)
 	{
 		cublasOperation_t op_a = transpose_a ? CUBLAS_OP_T : CUBLAS_OP_N;
 		cublasOperation_t op_b = transpose_b ? CUBLAS_OP_T : CUBLAS_OP_N;
@@ -112,7 +111,7 @@ namespace tsvd
 		safe_cublas(cublasSgemm(context.cublas_handle, op_a, op_b, m, n, k, &alpha, A.data(), lda, B.data(), ldb, &beta, C.data(), ldc));
 	}
 
-	void multiply(const Matrix<tsvd_double>& A, const Matrix<tsvd_double>& B, Matrix<tsvd_double>& C, DeviceContext& context, bool transpose_a, bool transpose_b, tsvd_double alpha)
+	void multiply(const Matrix<tsvd_double>& A, const Matrix<tsvd_double>& B, Matrix<tsvd_double>& C, device::DeviceContext& context, bool transpose_a, bool transpose_b, tsvd_double alpha)
 	{
 		cublasOperation_t op_a = transpose_a ? CUBLAS_OP_T : CUBLAS_OP_N;
 		cublasOperation_t op_b = transpose_b ? CUBLAS_OP_T : CUBLAS_OP_N;
@@ -129,7 +128,7 @@ namespace tsvd
 		safe_cublas(cublasDgemm(context.cublas_handle, op_a, op_b, m, n, k, &alpha, A.data(), lda, B.data(), ldb, &beta, C.data(), ldc));
 	}
 
-	void transpose(const Matrix<tsvd_float>& A, Matrix<tsvd_float>& B, DeviceContext& context)
+	void transpose(const Matrix<tsvd_float>& A, Matrix<tsvd_float>& B, device::DeviceContext& context)
 	{
 		h2o4gpu_check(A.rows() == B.columns()&&A.columns() == B.rows(), "Transpose dimensions incorrect");
 		const tsvd_float alpha = 1.0f;
@@ -137,7 +136,7 @@ namespace tsvd
 		safe_cublas(cublasSgeam(context.cublas_handle, CUBLAS_OP_T, CUBLAS_OP_N, B.rows(), B.columns(), &alpha, A.data(), A.rows(), &beta, NULL, B.rows(), B.data(), B.rows()));
 	}
 
-	void transpose(const Matrix<tsvd_double>& A, Matrix<tsvd_double>& B, DeviceContext& context)
+	void transpose(const Matrix<tsvd_double>& A, Matrix<tsvd_double>& B, device::DeviceContext& context)
 	{
 		h2o4gpu_check(A.rows() == B.columns()&&A.columns() == B.rows(), "Transpose dimensions incorrect");
 		const tsvd_double alpha = 1.0f;
@@ -145,7 +144,7 @@ namespace tsvd
 		safe_cublas(cublasDgeam(context.cublas_handle, CUBLAS_OP_T, CUBLAS_OP_N, B.rows(), B.columns(), &alpha, A.data(), A.rows(), &beta, NULL, B.rows(), B.data(), B.rows()));
 	}
 
-	void normalize_columns(Matrix<tsvd_float>& M, Matrix<tsvd_float>& M_temp, Matrix<tsvd_float>& column_length, const Matrix<tsvd_float>& ones, DeviceContext& context)
+	void normalize_columns(Matrix<tsvd_float>& M, Matrix<tsvd_float>& M_temp, Matrix<tsvd_float>& column_length, const Matrix<tsvd_float>& ones, device::DeviceContext& context)
 	{
 		thrust::transform(M.dptr(), M.dptr() + M.size(), M_temp.dptr(), sqr_op());
 		auto d_column_length = column_length.data();
@@ -167,7 +166,7 @@ namespace tsvd
 		safe_cublas(cublasSdgmm(context.cublas_handle, CUBLAS_SIDE_RIGHT, M.rows(), M.columns(), M.data(), M.rows(), d_column_length, 1, M.data(), M.rows()));
 	}
 
-	void normalize_columns(Matrix<tsvd_double>& M, Matrix<tsvd_double>& M_temp, Matrix<tsvd_double>& column_length, const Matrix<tsvd_double>& ones, DeviceContext& context)
+	void normalize_columns(Matrix<tsvd_double>& M, Matrix<tsvd_double>& M_temp, Matrix<tsvd_double>& column_length, const Matrix<tsvd_double>& ones, device::DeviceContext& context)
 	{
 		thrust::transform(M.dptr(), M.dptr() + M.size(), M_temp.dptr(), sqr_op());
 		auto d_column_length = column_length.data();
@@ -189,7 +188,7 @@ namespace tsvd
 		safe_cublas(cublasDdgmm(context.cublas_handle, CUBLAS_SIDE_RIGHT, M.rows(), M.columns(), M.data(), M.rows(), d_column_length, 1, M.data(), M.rows()));
 	}
 
-	void normalize_columns(Matrix<tsvd_float>& M, DeviceContext& context)
+	void normalize_columns(Matrix<tsvd_float>& M, device::DeviceContext& context)
 	{
 		Matrix<float> M_temp(M.rows(), M.columns());
 		Matrix<float> columns_length(1, M.columns());
@@ -198,7 +197,7 @@ namespace tsvd
 		normalize_columns(M, M_temp, columns_length, ones, context);
 	}
 
-	void normalize_columns(Matrix<tsvd_double>& M, DeviceContext& context)
+	void normalize_columns(Matrix<tsvd_double>& M, device::DeviceContext& context)
 	{
 		Matrix<double> M_temp(M.rows(), M.columns());
 		Matrix<double> columns_length(1, M.columns());
@@ -207,31 +206,31 @@ namespace tsvd
 		normalize_columns(M, M_temp, columns_length, ones, context);
 	}
 
-	void normalize_vector_cublas(Matrix<tsvd_float>& M, DeviceContext& context){
+	void normalize_vector_cublas(Matrix<tsvd_float>& M, device::DeviceContext& context){
         float norm2 = 0.0;
         safe_cublas(cublasSnrm2(context.cublas_handle, M.rows(), M.data(), 1.0, &norm2));
         M.transform([=]__device__ (float val){return val * (1/norm2);});
     }
 
-	void normalize_vector_cublas(Matrix<tsvd_double>& M, DeviceContext& context){
+	void normalize_vector_cublas(Matrix<tsvd_double>& M, device::DeviceContext& context){
         double norm2 = 0.0;
         safe_cublas(cublasDnrm2(context.cublas_handle, M.rows(), M.data(), 1.0, &norm2));
         M.transform([=]__device__ (float val){return val * (1/norm2);});
     }
 
-	void residual(const Matrix<tsvd_float>& X, const Matrix<tsvd_float>& D, const Matrix<tsvd_float>& S, Matrix<tsvd_float>& R, DeviceContext& context)
+	void residual(const Matrix<tsvd_float>& X, const Matrix<tsvd_float>& D, const Matrix<tsvd_float>& S, Matrix<tsvd_float>& R, device::DeviceContext& context)
 	{
 		multiply(D, S, R, context);
 		subtract(X, R, R, context);
 	}
 
-	void residual(const Matrix<tsvd_double>& X, const Matrix<tsvd_double>& D, const Matrix<tsvd_double>& S, Matrix<tsvd_double>& R, DeviceContext& context)
+	void residual(const Matrix<tsvd_double>& X, const Matrix<tsvd_double>& D, const Matrix<tsvd_double>& S, Matrix<tsvd_double>& R, device::DeviceContext& context)
 	{
 		multiply(D, S, R, context);
 		subtract(X, R, R, context);
 	}
 
-	void calculate_eigen_pairs_exact(const Matrix<tsvd_float>& X, Matrix<tsvd_float>& Q, Matrix<tsvd_float>& w, DeviceContext& context)
+	void calculate_eigen_pairs_exact(const Matrix<tsvd_float>& X, Matrix<tsvd_float>& Q, Matrix<tsvd_float>& w, device::DeviceContext& context)
 	{
 		h2o4gpu_check(X.rows() == X.columns(), "X must be a symmetric matrix");
 		h2o4gpu_check(X.rows() == Q.rows() && X.columns() == Q.columns(), "X and Q must have the same dimension");
@@ -253,7 +252,7 @@ namespace tsvd
 		safe_cuda(cudaGetLastError());
 	}
 
-	void calculate_eigen_pairs_exact(const Matrix<tsvd_double>& X, Matrix<tsvd_double>& Q, Matrix<tsvd_double>& w, DeviceContext& context)
+	void calculate_eigen_pairs_exact(const Matrix<tsvd_double>& X, Matrix<tsvd_double>& Q, Matrix<tsvd_double>& w, device::DeviceContext& context)
 	{
 		h2o4gpu_check(X.rows() == X.columns(), "X must be a symmetric matrix");
 		h2o4gpu_check(X.rows() == Q.rows() && X.columns() == Q.columns(), "X and Q must have the same dimension");
@@ -275,19 +274,19 @@ namespace tsvd
 		safe_cuda(cudaGetLastError());
 	}
 
-	void dot_product(Matrix<tsvd_float>& b_k1, Matrix<tsvd_float>& b_k, float* eigen_value_estimate, DeviceContext& context)
+	void dot_product(Matrix<tsvd_float>& b_k1, Matrix<tsvd_float>& b_k, float* eigen_value_estimate, device::DeviceContext& context)
 	{
 		safe_cublas(cublasSdot(context.cublas_handle, b_k1.rows(), b_k1.data(), 1.0, b_k.data(), 1.0, eigen_value_estimate));
 	}
 
-	void dot_product(Matrix<tsvd_double>& b_k1, Matrix<tsvd_double>& b_k, double* eigen_value_estimate, DeviceContext& context)
+	void dot_product(Matrix<tsvd_double>& b_k1, Matrix<tsvd_double>& b_k, double* eigen_value_estimate, device::DeviceContext& context)
 	{
 		safe_cublas(cublasDdot(context.cublas_handle, b_k1.rows(), b_k1.data(), 1.0, b_k.data(), 1.0, eigen_value_estimate));
 	}
 
 	//----------------------------------------------------------------------------------------------------------------------------------------------------------------------
 	//Stricly floating point operations that are not used
-	void linear_solve(const Matrix<tsvd_float>& A, Matrix<tsvd_float>& X, const Matrix<tsvd_float>& B, DeviceContext& context)
+	void linear_solve(const Matrix<tsvd_float>& A, Matrix<tsvd_float>& X, const Matrix<tsvd_float>& B, device::DeviceContext& context)
 	{
 		h2o4gpu_check(A.rows()>= A.columns(),"Linear solve requires m >= n");
 		h2o4gpu_check(X.rows()>= X.columns(),"Linear solve requires n >= k"); //TODO: is this restriction necessary?
@@ -344,7 +343,7 @@ namespace tsvd
 		thrust::copy(QTB.dptr(), QTB.dptr() + QTB.size(), X.data());
 	}
 
-	void pseudoinverse(const Matrix<tsvd_float>& A, Matrix<tsvd_float>& pinvA, DeviceContext& context)
+	void pseudoinverse(const Matrix<tsvd_float>& A, Matrix<tsvd_float>& pinvA, device::DeviceContext& context)
 	{
 		h2o4gpu_check(A.rows() == pinvA.columns() && A.columns() == pinvA.rows(), "pseudoinverse dimensions incorrect");
 
@@ -411,7 +410,7 @@ namespace tsvd
 		thrust::copy(pinvA_extended.dptr(), pinvA_extended.dptr() + pinvA.size(), pinvA.dptr());
 	}
 
-	void f_normalize(Matrix<tsvd_float>& M, DeviceContext& context)
+	void f_normalize(Matrix<tsvd_float>& M, device::DeviceContext& context)
 	{
 		Matrix<tsvd_float> temp(M.rows(), M.columns());
 		thrust::transform(M.dptr(), M.dptr() + M.size(), temp.dptr(), sqr_op());
@@ -422,7 +421,7 @@ namespace tsvd
 		printf("f norm sum squares: %1.4f\n", final_sum);
 	}
 
-	void normalize_columns_cub(Matrix<tsvd_float>& M, DeviceContext& context)
+	void normalize_columns_cub(Matrix<tsvd_float>& M, device::DeviceContext& context)
 	{
 		//Create alias so device Lamba does not dereference this pointer
 		int m = M.rows();
@@ -481,15 +480,15 @@ namespace tsvd
 }
 
 //Orignal Impl
-template void tsvd::multiply<double>(Matrix<double>& A, const float a, DeviceContext& context);
+template void tsvd::multiply<double>(Matrix<double>& A, const float a, device::DeviceContext& context);
 
 //Impl for floats and doubles
-template void tsvd::multiply<float>(Matrix<float>& A, const float a, DeviceContext& context);
-template void tsvd::multiply<double>(Matrix<double>& A, const double a, DeviceContext& context);
-template void tsvd::subtract<float>(const Matrix<float>& A, const Matrix<float>& B, Matrix<float>& C, DeviceContext& context);
-template void tsvd::subtract<double>(const Matrix<double>& A, const Matrix<double>& B, Matrix<double>& C, DeviceContext& context);
-template void tsvd::add<float>(const Matrix<float>& A, const Matrix<float>& B, Matrix<float>& C, DeviceContext& context);
-template void tsvd::add<double>(const Matrix<double>& A, const Matrix<double>& B, Matrix<double>& C, DeviceContext& context);
-template void tsvd::normalize_vector_thrust<float>(Matrix<float>& M, DeviceContext& context);
-template void tsvd::normalize_vector_thrust<double>(Matrix<double>& M, DeviceContext& context);
+template void tsvd::multiply<float>(Matrix<float>& A, const float a, device::DeviceContext& context);
+template void tsvd::multiply<double>(Matrix<double>& A, const double a, device::DeviceContext& context);
+template void tsvd::subtract<float>(const Matrix<float>& A, const Matrix<float>& B, Matrix<float>& C, device::DeviceContext& context);
+template void tsvd::subtract<double>(const Matrix<double>& A, const Matrix<double>& B, Matrix<double>& C, device::DeviceContext& context);
+template void tsvd::add<float>(const Matrix<float>& A, const Matrix<float>& B, Matrix<float>& C, device::DeviceContext& context);
+template void tsvd::add<double>(const Matrix<double>& A, const Matrix<double>& B, Matrix<double>& C, device::DeviceContext& context);
+template void tsvd::normalize_vector_thrust<float>(Matrix<float>& M, device::DeviceContext& context);
+template void tsvd::normalize_vector_thrust<double>(Matrix<double>& M, device::DeviceContext& context);
 

--- a/src/gpu/data/matrix.cu
+++ b/src/gpu/data/matrix.cu
@@ -3,11 +3,11 @@
 #include <thrust/inner_product.h>
 #include <thrust/extrema.h>
 
-namespace tsvd
+namespace matrix
 {
 	using namespace h2o4gpu;
 
-	void max_index_per_column(Matrix<tsvd_float>& A, std::vector<int>& result_array, device::DeviceContext& context){
+	void max_index_per_column(Matrix<matrix_float>& A, std::vector<int>& result_array, device::DeviceContext& context){
 
 		int result;
 		for (int i=0; i<A.columns(); i++) {
@@ -16,7 +16,7 @@ namespace tsvd
 		}
 	}
 
-	void max_index_per_column(Matrix<tsvd_double>& A, std::vector<int>& result_array, device::DeviceContext& context){
+	void max_index_per_column(Matrix<matrix_double>& A, std::vector<int>& result_array, device::DeviceContext& context){
 
 		int result;
 		for (int i=0; i<A.columns(); i++) {
@@ -68,7 +68,7 @@ namespace tsvd
 		M.transform([=]__device__ (float val){return val / std::sqrt(M_inner);});
 	}
 
-	void multiply_diag(const Matrix<tsvd_float>& A, const Matrix<tsvd_float>& B, Matrix<tsvd_float>& C, device::DeviceContext& context, bool left_diag)
+	void multiply_diag(const Matrix<matrix_float>& A, const Matrix<matrix_float>& B, Matrix<matrix_float>& C, device::DeviceContext& context, bool left_diag)
 	{
 		cublasSideMode_t mode = left_diag ? CUBLAS_SIDE_LEFT : CUBLAS_SIDE_RIGHT;
 
@@ -81,7 +81,7 @@ namespace tsvd
 		safe_cublas(cublasSdgmm(context.cublas_handle, mode, m, n, A.data(), lda, B.data(), incx, C.data(), ldc));
 	}
 
-	void multiply_diag(const Matrix<tsvd_double>& A, const Matrix<tsvd_double>& B, Matrix<tsvd_double>& C, device::DeviceContext& context, bool left_diag)
+	void multiply_diag(const Matrix<matrix_double>& A, const Matrix<matrix_double>& B, Matrix<matrix_double>& C, device::DeviceContext& context, bool left_diag)
 	{
 		cublasSideMode_t mode = left_diag ? CUBLAS_SIDE_LEFT : CUBLAS_SIDE_RIGHT;
 
@@ -94,12 +94,12 @@ namespace tsvd
 		safe_cublas(cublasDdgmm(context.cublas_handle, mode, m, n, A.data(), lda, B.data(), incx, C.data(), ldc));
 	}
 
-	void multiply(const Matrix<tsvd_float>& A, const Matrix<tsvd_float>& B, Matrix<tsvd_float>& C, device::DeviceContext& context, bool transpose_a, bool transpose_b, tsvd_float alpha)
+	void multiply(const Matrix<matrix_float>& A, const Matrix<matrix_float>& B, Matrix<matrix_float>& C, device::DeviceContext& context, bool transpose_a, bool transpose_b, matrix_float alpha)
 	{
 		cublasOperation_t op_a = transpose_a ? CUBLAS_OP_T : CUBLAS_OP_N;
 		cublasOperation_t op_b = transpose_b ? CUBLAS_OP_T : CUBLAS_OP_N;
 
-		const tsvd_float beta = 0;
+		const matrix_float beta = 0;
 
 		int m = C.rows();
 		int n = C.columns();
@@ -111,12 +111,12 @@ namespace tsvd
 		safe_cublas(cublasSgemm(context.cublas_handle, op_a, op_b, m, n, k, &alpha, A.data(), lda, B.data(), ldb, &beta, C.data(), ldc));
 	}
 
-	void multiply(const Matrix<tsvd_double>& A, const Matrix<tsvd_double>& B, Matrix<tsvd_double>& C, device::DeviceContext& context, bool transpose_a, bool transpose_b, tsvd_double alpha)
+	void multiply(const Matrix<matrix_double>& A, const Matrix<matrix_double>& B, Matrix<matrix_double>& C, device::DeviceContext& context, bool transpose_a, bool transpose_b, matrix_double alpha)
 	{
 		cublasOperation_t op_a = transpose_a ? CUBLAS_OP_T : CUBLAS_OP_N;
 		cublasOperation_t op_b = transpose_b ? CUBLAS_OP_T : CUBLAS_OP_N;
 
-		const tsvd_double beta = 0;
+		const matrix_double beta = 0;
 
 		int m = C.rows();
 		int n = C.columns();
@@ -128,32 +128,32 @@ namespace tsvd
 		safe_cublas(cublasDgemm(context.cublas_handle, op_a, op_b, m, n, k, &alpha, A.data(), lda, B.data(), ldb, &beta, C.data(), ldc));
 	}
 
-	void transpose(const Matrix<tsvd_float>& A, Matrix<tsvd_float>& B, device::DeviceContext& context)
+	void transpose(const Matrix<matrix_float>& A, Matrix<matrix_float>& B, device::DeviceContext& context)
 	{
 		h2o4gpu_check(A.rows() == B.columns()&&A.columns() == B.rows(), "Transpose dimensions incorrect");
-		const tsvd_float alpha = 1.0f;
-		const tsvd_float beta = 0.0f;
+		const matrix_float alpha = 1.0f;
+		const matrix_float beta = 0.0f;
 		safe_cublas(cublasSgeam(context.cublas_handle, CUBLAS_OP_T, CUBLAS_OP_N, B.rows(), B.columns(), &alpha, A.data(), A.rows(), &beta, NULL, B.rows(), B.data(), B.rows()));
 	}
 
-	void transpose(const Matrix<tsvd_double>& A, Matrix<tsvd_double>& B, device::DeviceContext& context)
+	void transpose(const Matrix<matrix_double>& A, Matrix<matrix_double>& B, device::DeviceContext& context)
 	{
 		h2o4gpu_check(A.rows() == B.columns()&&A.columns() == B.rows(), "Transpose dimensions incorrect");
-		const tsvd_double alpha = 1.0f;
-		const tsvd_double beta = 0.0f;
+		const matrix_double alpha = 1.0f;
+		const matrix_double beta = 0.0f;
 		safe_cublas(cublasDgeam(context.cublas_handle, CUBLAS_OP_T, CUBLAS_OP_N, B.rows(), B.columns(), &alpha, A.data(), A.rows(), &beta, NULL, B.rows(), B.data(), B.rows()));
 	}
 
-	void normalize_columns(Matrix<tsvd_float>& M, Matrix<tsvd_float>& M_temp, Matrix<tsvd_float>& column_length, const Matrix<tsvd_float>& ones, device::DeviceContext& context)
+	void normalize_columns(Matrix<matrix_float>& M, Matrix<matrix_float>& M_temp, Matrix<matrix_float>& column_length, const Matrix<matrix_float>& ones, device::DeviceContext& context)
 	{
 		thrust::transform(M.dptr(), M.dptr() + M.size(), M_temp.dptr(), sqr_op());
 		auto d_column_length = column_length.data();
 		auto d_ones = ones.data();
-		const tsvd_float alpha = 1.0f;
-		const tsvd_float beta = 0.0f;
+		const matrix_float alpha = 1.0f;
+		const matrix_float beta = 0.0f;
 		safe_cublas(cublasSgemv(context.cublas_handle, CUBLAS_OP_T, M.rows(), M.columns(), &alpha, M_temp.data(), M.rows(), d_ones, 1, &beta, d_column_length, 1));
 
-		thrust::transform(column_length.dptr(), column_length.dptr() + column_length.size(), column_length.dptr(), [=]__device__(tsvd_float val)
+		thrust::transform(column_length.dptr(), column_length.dptr() + column_length.size(), column_length.dptr(), [=]__device__(matrix_float val)
 		                  {
 							  if (val == 0.0)
 							  {
@@ -166,16 +166,16 @@ namespace tsvd
 		safe_cublas(cublasSdgmm(context.cublas_handle, CUBLAS_SIDE_RIGHT, M.rows(), M.columns(), M.data(), M.rows(), d_column_length, 1, M.data(), M.rows()));
 	}
 
-	void normalize_columns(Matrix<tsvd_double>& M, Matrix<tsvd_double>& M_temp, Matrix<tsvd_double>& column_length, const Matrix<tsvd_double>& ones, device::DeviceContext& context)
+	void normalize_columns(Matrix<matrix_double>& M, Matrix<matrix_double>& M_temp, Matrix<matrix_double>& column_length, const Matrix<matrix_double>& ones, device::DeviceContext& context)
 	{
 		thrust::transform(M.dptr(), M.dptr() + M.size(), M_temp.dptr(), sqr_op());
 		auto d_column_length = column_length.data();
 		auto d_ones = ones.data();
-		const tsvd_double alpha = 1.0f;
-		const tsvd_double beta = 0.0f;
+		const matrix_double alpha = 1.0f;
+		const matrix_double beta = 0.0f;
 		safe_cublas(cublasDgemv(context.cublas_handle, CUBLAS_OP_T, M.rows(), M.columns(), &alpha, M_temp.data(), M.rows(), d_ones, 1, &beta, d_column_length, 1));
 
-		thrust::transform(column_length.dptr(), column_length.dptr() + column_length.size(), column_length.dptr(), [=]__device__(tsvd_double val)
+		thrust::transform(column_length.dptr(), column_length.dptr() + column_length.size(), column_length.dptr(), [=]__device__(matrix_double val)
 		                  {
 							  if (val == 0.0)
 							  {
@@ -188,7 +188,7 @@ namespace tsvd
 		safe_cublas(cublasDdgmm(context.cublas_handle, CUBLAS_SIDE_RIGHT, M.rows(), M.columns(), M.data(), M.rows(), d_column_length, 1, M.data(), M.rows()));
 	}
 
-	void normalize_columns(Matrix<tsvd_float>& M, device::DeviceContext& context)
+	void normalize_columns(Matrix<matrix_float>& M, device::DeviceContext& context)
 	{
 		Matrix<float> M_temp(M.rows(), M.columns());
 		Matrix<float> columns_length(1, M.columns());
@@ -197,7 +197,7 @@ namespace tsvd
 		normalize_columns(M, M_temp, columns_length, ones, context);
 	}
 
-	void normalize_columns(Matrix<tsvd_double>& M, device::DeviceContext& context)
+	void normalize_columns(Matrix<matrix_double>& M, device::DeviceContext& context)
 	{
 		Matrix<double> M_temp(M.rows(), M.columns());
 		Matrix<double> columns_length(1, M.columns());
@@ -206,31 +206,31 @@ namespace tsvd
 		normalize_columns(M, M_temp, columns_length, ones, context);
 	}
 
-	void normalize_vector_cublas(Matrix<tsvd_float>& M, device::DeviceContext& context){
+	void normalize_vector_cublas(Matrix<matrix_float>& M, device::DeviceContext& context){
         float norm2 = 0.0;
         safe_cublas(cublasSnrm2(context.cublas_handle, M.rows(), M.data(), 1.0, &norm2));
         M.transform([=]__device__ (float val){return val * (1/norm2);});
     }
 
-	void normalize_vector_cublas(Matrix<tsvd_double>& M, device::DeviceContext& context){
+	void normalize_vector_cublas(Matrix<matrix_double>& M, device::DeviceContext& context){
         double norm2 = 0.0;
         safe_cublas(cublasDnrm2(context.cublas_handle, M.rows(), M.data(), 1.0, &norm2));
         M.transform([=]__device__ (float val){return val * (1/norm2);});
     }
 
-	void residual(const Matrix<tsvd_float>& X, const Matrix<tsvd_float>& D, const Matrix<tsvd_float>& S, Matrix<tsvd_float>& R, device::DeviceContext& context)
+	void residual(const Matrix<matrix_float>& X, const Matrix<matrix_float>& D, const Matrix<matrix_float>& S, Matrix<matrix_float>& R, device::DeviceContext& context)
 	{
 		multiply(D, S, R, context);
 		subtract(X, R, R, context);
 	}
 
-	void residual(const Matrix<tsvd_double>& X, const Matrix<tsvd_double>& D, const Matrix<tsvd_double>& S, Matrix<tsvd_double>& R, device::DeviceContext& context)
+	void residual(const Matrix<matrix_double>& X, const Matrix<matrix_double>& D, const Matrix<matrix_double>& S, Matrix<matrix_double>& R, device::DeviceContext& context)
 	{
 		multiply(D, S, R, context);
 		subtract(X, R, R, context);
 	}
 
-	void calculate_eigen_pairs_exact(const Matrix<tsvd_float>& X, Matrix<tsvd_float>& Q, Matrix<tsvd_float>& w, device::DeviceContext& context)
+	void calculate_eigen_pairs_exact(const Matrix<matrix_float>& X, Matrix<matrix_float>& Q, Matrix<matrix_float>& w, device::DeviceContext& context)
 	{
 		h2o4gpu_check(X.rows() == X.columns(), "X must be a symmetric matrix");
 		h2o4gpu_check(X.rows() == Q.rows() && X.columns() == Q.columns(), "X and Q must have the same dimension");
@@ -252,7 +252,7 @@ namespace tsvd
 		safe_cuda(cudaGetLastError());
 	}
 
-	void calculate_eigen_pairs_exact(const Matrix<tsvd_double>& X, Matrix<tsvd_double>& Q, Matrix<tsvd_double>& w, device::DeviceContext& context)
+	void calculate_eigen_pairs_exact(const Matrix<matrix_double>& X, Matrix<matrix_double>& Q, Matrix<matrix_double>& w, device::DeviceContext& context)
 	{
 		h2o4gpu_check(X.rows() == X.columns(), "X must be a symmetric matrix");
 		h2o4gpu_check(X.rows() == Q.rows() && X.columns() == Q.columns(), "X and Q must have the same dimension");
@@ -274,36 +274,36 @@ namespace tsvd
 		safe_cuda(cudaGetLastError());
 	}
 
-	void dot_product(Matrix<tsvd_float>& b_k1, Matrix<tsvd_float>& b_k, float* eigen_value_estimate, device::DeviceContext& context)
+	void dot_product(Matrix<matrix_float>& b_k1, Matrix<matrix_float>& b_k, float* eigen_value_estimate, device::DeviceContext& context)
 	{
 		safe_cublas(cublasSdot(context.cublas_handle, b_k1.rows(), b_k1.data(), 1.0, b_k.data(), 1.0, eigen_value_estimate));
 	}
 
-	void dot_product(Matrix<tsvd_double>& b_k1, Matrix<tsvd_double>& b_k, double* eigen_value_estimate, device::DeviceContext& context)
+	void dot_product(Matrix<matrix_double>& b_k1, Matrix<matrix_double>& b_k, double* eigen_value_estimate, device::DeviceContext& context)
 	{
 		safe_cublas(cublasDdot(context.cublas_handle, b_k1.rows(), b_k1.data(), 1.0, b_k.data(), 1.0, eigen_value_estimate));
 	}
 
 	//----------------------------------------------------------------------------------------------------------------------------------------------------------------------
 	//Stricly floating point operations that are not used
-	void linear_solve(const Matrix<tsvd_float>& A, Matrix<tsvd_float>& X, const Matrix<tsvd_float>& B, device::DeviceContext& context)
+	void linear_solve(const Matrix<matrix_float>& A, Matrix<matrix_float>& X, const Matrix<matrix_float>& B, device::DeviceContext& context)
 	{
 		h2o4gpu_check(A.rows()>= A.columns(),"Linear solve requires m >= n");
 		h2o4gpu_check(X.rows()>= X.columns(),"Linear solve requires n >= k"); //TODO: is this restriction necessary?
 
-		Matrix<tsvd_float> A_copy(A);
-		Matrix<tsvd_float> B_copy(A.rows(), A.columns());
+		Matrix<matrix_float> A_copy(A);
+		Matrix<matrix_float> B_copy(A.rows(), A.columns());
 		thrust::copy(B.dptr(), B.dptr() + B.size(), B_copy.dptr());
 		thrust::fill(B_copy.dptr() + B.size(), B_copy.dptr() + B_copy.size(), 0.0f);
 
 		int work_size = 0;
 		safe_cusolver(cusolverDnSgeqrf_bufferSize(context.cusolver_handle, A_copy.rows(), A_copy.columns(), A_copy.data(), A_copy.rows(), &work_size));
 
-		thrust::device_vector<tsvd_float> work(work_size);
-		tsvd_float* d_work = thrust::raw_pointer_cast(work.data());
+		thrust::device_vector<matrix_float> work(work_size);
+		matrix_float* d_work = thrust::raw_pointer_cast(work.data());
 
-		thrust::device_vector<tsvd_float> tau((std::min)(A.rows(), A.columns()));
-		tsvd_float* d_tau = thrust::raw_pointer_cast(tau.data());
+		thrust::device_vector<matrix_float> tau((std::min)(A.rows(), A.columns()));
+		matrix_float* d_tau = thrust::raw_pointer_cast(tau.data());
 
 		thrust::device_vector<int> dev_info(1);
 		int* d_dev_info = thrust::raw_pointer_cast(dev_info.data());
@@ -315,8 +315,8 @@ namespace tsvd
 		safe_cusolver(cusolverDnSormqr(context.cusolver_handle, CUBLAS_SIDE_LEFT, CUBLAS_OP_T, A.rows(), A.columns(), (std::min)(A.rows(), A.columns()), A_copy.data(), A.rows(), d_tau, B_copy.data(), A.rows(), d_work, work_size, d_dev_info));
 		h2o4gpu_check(dev_info[0] == 0, "ormqr unsuccessful");
 
-		Matrix<tsvd_float> R(A.columns(), A.columns());
-		Matrix<tsvd_float> QTB(A.columns(), B.columns());
+		Matrix<matrix_float> R(A.columns(), A.columns());
+		Matrix<matrix_float> QTB(A.columns(), B.columns());
 		auto counting = thrust::make_counting_iterator(0);
 		int n = R.columns();
 		int m = A.rows();
@@ -337,18 +337,18 @@ namespace tsvd
 			                 }
 		                 });
 
-		const tsvd_float alpha = 1.0f;
+		const matrix_float alpha = 1.0f;
 		safe_cublas(cublasStrsm(context.cublas_handle, CUBLAS_SIDE_LEFT, CUBLAS_FILL_MODE_UPPER, CUBLAS_OP_N, CUBLAS_DIAG_NON_UNIT, QTB.rows(), QTB.columns(), &alpha, R.data(), R.rows(), QTB.data(), QTB.rows()));
 
 		thrust::copy(QTB.dptr(), QTB.dptr() + QTB.size(), X.data());
 	}
 
-	void pseudoinverse(const Matrix<tsvd_float>& A, Matrix<tsvd_float>& pinvA, device::DeviceContext& context)
+	void pseudoinverse(const Matrix<matrix_float>& A, Matrix<matrix_float>& pinvA, device::DeviceContext& context)
 	{
 		h2o4gpu_check(A.rows() == pinvA.columns() && A.columns() == pinvA.rows(), "pseudoinverse dimensions incorrect");
 
 		//Add zero rows if m < n such that m >= n
-		Matrix<tsvd_float> A_extended((std::max)(A.columns(), A.rows()), A.columns());
+		Matrix<matrix_float> A_extended((std::max)(A.columns(), A.rows()), A.columns());
 		auto counting = thrust::make_counting_iterator(0);
 		int A_column_size = A.rows();
 		int A_extended_column_size = A_extended.rows();
@@ -373,17 +373,17 @@ namespace tsvd
 		int work_size = 0;
 		safe_cusolver(cusolverDnSgesvd_bufferSize(context.cusolver_handle, A_extended.rows(), A_extended.columns(), &work_size));
 
-		Matrix<tsvd_float> work(work_size, 1);
+		Matrix<matrix_float> work(work_size, 1);
 
-		Matrix<tsvd_float> S((std::min)(A_extended.rows(), A_extended.columns()), 1);
-		Matrix<tsvd_float> U(A_extended.rows(), A_extended.rows());
-		Matrix<tsvd_float> VT(A_extended.columns(), A_extended.columns());
+		Matrix<matrix_float> S((std::min)(A_extended.rows(), A_extended.columns()), 1);
+		Matrix<matrix_float> U(A_extended.rows(), A_extended.rows());
+		Matrix<matrix_float> VT(A_extended.columns(), A_extended.columns());
 		Matrix<int> dev_info(1, 1);
 
 		safe_cusolver (cusolverDnSgesvd(context.cusolver_handle, 'A', 'A', A_extended.rows(), A_extended.columns(), d_A_extended, A_extended.rows(), S.data(), U.data(), U.rows(), VT.data(), VT.rows(), work.data(), work_size, NULL, dev_info.data()));
 
-		tsvd_float eps = 1e-5;
-		thrust::transform(S.dptr(), S.dptr() + S.size(), S.dptr(), [=]__device__(tsvd_float val)
+		matrix_float eps = 1e-5;
+		thrust::transform(S.dptr(), S.dptr() + S.size(), S.dptr(), [=]__device__(matrix_float val)
 		                  {
 			                  if (abs(val) < eps)
 			                  {
@@ -395,41 +395,41 @@ namespace tsvd
 			                  }
 		                  });
 
-		Matrix<tsvd_float> UT(A_extended.rows(), A_extended.rows());
+		Matrix<matrix_float> UT(A_extended.rows(), A_extended.rows());
 
 		//Calculate transpose of U
-		const tsvd_float alpha = 1.0;
-		const tsvd_float beta = 0.0;
+		const matrix_float alpha = 1.0;
+		const matrix_float beta = 0.0;
 		safe_cublas(cublasSgeam(context.cublas_handle, CUBLAS_OP_T, CUBLAS_OP_N, UT.rows(), UT.columns(), &alpha, U.data(), UT.rows(), &beta,NULL, UT.rows(), UT.data(), UT.rows()));
 
 		safe_cublas(cublasSdgmm(context.cublas_handle, CUBLAS_SIDE_LEFT, UT.rows(), UT.columns(), UT.data(), UT.rows(), S.data(), 1, U.data(), U.rows()));
 
-		Matrix<tsvd_float> pinvA_extended(A_extended.columns(), A_extended.rows());
+		Matrix<matrix_float> pinvA_extended(A_extended.columns(), A_extended.rows());
 		multiply(VT, U, pinvA_extended, context, true);
 
 		thrust::copy(pinvA_extended.dptr(), pinvA_extended.dptr() + pinvA.size(), pinvA.dptr());
 	}
 
-	void f_normalize(Matrix<tsvd_float>& M, device::DeviceContext& context)
+	void f_normalize(Matrix<matrix_float>& M, device::DeviceContext& context)
 	{
-		Matrix<tsvd_float> temp(M.rows(), M.columns());
+		Matrix<matrix_float> temp(M.rows(), M.columns());
 		thrust::transform(M.dptr(), M.dptr() + M.size(), temp.dptr(), sqr_op());
-		tsvd_float sum = thrust::reduce(temp.dptr(), temp.dptr() + temp.size());
+		matrix_float sum = thrust::reduce(temp.dptr(), temp.dptr() + temp.size());
 		multiply(M, 1.0 / std::sqrt(sum), context);
 		thrust::transform(M.dptr(), M.dptr() + M.size(), temp.dptr(), sqr_op());
-		tsvd_float final_sum = thrust::reduce(temp.dptr(), temp.dptr() + temp.size());
+		matrix_float final_sum = thrust::reduce(temp.dptr(), temp.dptr() + temp.size());
 		printf("f norm sum squares: %1.4f\n", final_sum);
 	}
 
-	void normalize_columns_cub(Matrix<tsvd_float>& M, device::DeviceContext& context)
+	void normalize_columns_cub(Matrix<matrix_float>& M, device::DeviceContext& context)
 	{
 		//Create alias so device Lamba does not dereference this pointer
 		int m = M.rows();
 
-		thrust::device_vector<tsvd_float> temp(M.size());
-		thrust::device_vector<tsvd_float> length_squared(M.columns());
+		thrust::device_vector<matrix_float> temp(M.size());
+		thrust::device_vector<matrix_float> length_squared(M.columns());
 
-		thrust::transform(M.dptr(), M.dptr() + M.size(), temp.begin(), [=]__device__(tsvd_float val)
+		thrust::transform(M.dptr(), M.dptr() + M.size(), temp.begin(), [=]__device__(matrix_float val)
 		                  {
 			                  return val * val;
 		                  });
@@ -462,7 +462,7 @@ namespace tsvd
 		                  {
 			                  int col = idx / m;
 
-			                  tsvd_float length_squared = d_length_squared[col];
+			                  matrix_float length_squared = d_length_squared[col];
 
 			                  if (length_squared > 0.0)
 			                  {
@@ -480,15 +480,15 @@ namespace tsvd
 }
 
 //Orignal Impl
-template void tsvd::multiply<double>(Matrix<double>& A, const float a, device::DeviceContext& context);
+template void matrix::multiply<double>(Matrix<double>& A, const float a, device::DeviceContext& context);
 
 //Impl for floats and doubles
-template void tsvd::multiply<float>(Matrix<float>& A, const float a, device::DeviceContext& context);
-template void tsvd::multiply<double>(Matrix<double>& A, const double a, device::DeviceContext& context);
-template void tsvd::subtract<float>(const Matrix<float>& A, const Matrix<float>& B, Matrix<float>& C, device::DeviceContext& context);
-template void tsvd::subtract<double>(const Matrix<double>& A, const Matrix<double>& B, Matrix<double>& C, device::DeviceContext& context);
-template void tsvd::add<float>(const Matrix<float>& A, const Matrix<float>& B, Matrix<float>& C, device::DeviceContext& context);
-template void tsvd::add<double>(const Matrix<double>& A, const Matrix<double>& B, Matrix<double>& C, device::DeviceContext& context);
-template void tsvd::normalize_vector_thrust<float>(Matrix<float>& M, device::DeviceContext& context);
-template void tsvd::normalize_vector_thrust<double>(Matrix<double>& M, device::DeviceContext& context);
+template void matrix::multiply<float>(Matrix<float>& A, const float a, device::DeviceContext& context);
+template void matrix::multiply<double>(Matrix<double>& A, const double a, device::DeviceContext& context);
+template void matrix::subtract<float>(const Matrix<float>& A, const Matrix<float>& B, Matrix<float>& C, device::DeviceContext& context);
+template void matrix::subtract<double>(const Matrix<double>& A, const Matrix<double>& B, Matrix<double>& C, device::DeviceContext& context);
+template void matrix::add<float>(const Matrix<float>& A, const Matrix<float>& B, Matrix<float>& C, device::DeviceContext& context);
+template void matrix::add<double>(const Matrix<double>& A, const Matrix<double>& B, Matrix<double>& C, device::DeviceContext& context);
+template void matrix::normalize_vector_thrust<float>(Matrix<float>& M, device::DeviceContext& context);
+template void matrix::normalize_vector_thrust<double>(Matrix<double>& M, device::DeviceContext& context);
 

--- a/src/gpu/data/matrix.cu
+++ b/src/gpu/data/matrix.cu
@@ -128,7 +128,7 @@ namespace tsvd
 
 	void transpose(const Matrix<tsvd_float>& A, Matrix<tsvd_float>& B, DeviceContext& context)
 	{
-		tsvd_check(A.rows() == B.columns()&&A.columns() == B.rows(), "Transpose dimensions incorrect");
+		h2o4gpu_check(A.rows() == B.columns()&&A.columns() == B.rows(), "Transpose dimensions incorrect");
 		const tsvd_float alpha = 1.0f;
 		const tsvd_float beta = 0.0f;
 		safe_cublas(cublasSgeam(context.cublas_handle, CUBLAS_OP_T, CUBLAS_OP_N, B.rows(), B.columns(), &alpha, A.data(), A.rows(), &beta, NULL, B.rows(), B.data(), B.rows()));
@@ -136,7 +136,7 @@ namespace tsvd
 
 	void transpose(const Matrix<tsvd_double>& A, Matrix<tsvd_double>& B, DeviceContext& context)
 	{
-		tsvd_check(A.rows() == B.columns()&&A.columns() == B.rows(), "Transpose dimensions incorrect");
+		h2o4gpu_check(A.rows() == B.columns()&&A.columns() == B.rows(), "Transpose dimensions incorrect");
 		const tsvd_double alpha = 1.0f;
 		const tsvd_double beta = 0.0f;
 		safe_cublas(cublasDgeam(context.cublas_handle, CUBLAS_OP_T, CUBLAS_OP_N, B.rows(), B.columns(), &alpha, A.data(), A.rows(), &beta, NULL, B.rows(), B.data(), B.rows()));
@@ -230,9 +230,9 @@ namespace tsvd
 
 	void calculate_eigen_pairs_exact(const Matrix<tsvd_float>& X, Matrix<tsvd_float>& Q, Matrix<tsvd_float>& w, DeviceContext& context)
 	{
-		tsvd_check(X.rows() == X.columns(), "X must be a symmetric matrix");
-		tsvd_check(X.rows() == Q.rows() && X.columns() == Q.columns(), "X and Q must have the same dimension");
-		tsvd_check(w.rows() == Q.columns(), "Q and w should have the same number of columns");
+		h2o4gpu_check(X.rows() == X.columns(), "X must be a symmetric matrix");
+		h2o4gpu_check(X.rows() == Q.rows() && X.columns() == Q.columns(), "X and Q must have the same dimension");
+		h2o4gpu_check(w.rows() == Q.columns(), "Q and w should have the same number of columns");
 
 		int lwork;
 		safe_cusolver(cusolverDnSsyevd_bufferSize(context.cusolver_handle, CUSOLVER_EIG_MODE_VECTOR, CUBLAS_FILL_MODE_UPPER, X.rows(), X.data(), X.columns(), w.data(), &lwork));
@@ -252,9 +252,9 @@ namespace tsvd
 
 	void calculate_eigen_pairs_exact(const Matrix<tsvd_double>& X, Matrix<tsvd_double>& Q, Matrix<tsvd_double>& w, DeviceContext& context)
 	{
-		tsvd_check(X.rows() == X.columns(), "X must be a symmetric matrix");
-		tsvd_check(X.rows() == Q.rows() && X.columns() == Q.columns(), "X and Q must have the same dimension");
-		tsvd_check(w.rows() == Q.columns(), "Q and w should have the same number of columns");
+		h2o4gpu_check(X.rows() == X.columns(), "X must be a symmetric matrix");
+		h2o4gpu_check(X.rows() == Q.rows() && X.columns() == Q.columns(), "X and Q must have the same dimension");
+		h2o4gpu_check(w.rows() == Q.columns(), "Q and w should have the same number of columns");
 
 		int lwork;
 		safe_cusolver(cusolverDnDsyevd_bufferSize(context.cusolver_handle, CUSOLVER_EIG_MODE_VECTOR, CUBLAS_FILL_MODE_UPPER, X.rows(), X.data(), X.columns(), w.data(), &lwork));
@@ -286,8 +286,8 @@ namespace tsvd
 	//Stricly floating point operations that are not used
 	void linear_solve(const Matrix<tsvd_float>& A, Matrix<tsvd_float>& X, const Matrix<tsvd_float>& B, DeviceContext& context)
 	{
-		tsvd_check(A.rows()>= A.columns(),"Linear solve requires m >= n");
-		tsvd_check(X.rows()>= X.columns(),"Linear solve requires n >= k"); //TODO: is this restriction necessary?
+		h2o4gpu_check(A.rows()>= A.columns(),"Linear solve requires m >= n");
+		h2o4gpu_check(X.rows()>= X.columns(),"Linear solve requires n >= k"); //TODO: is this restriction necessary?
 
 		Matrix<tsvd_float> A_copy(A);
 		Matrix<tsvd_float> B_copy(A.rows(), A.columns());
@@ -308,10 +308,10 @@ namespace tsvd
 
 		safe_cusolver(cusolverDnSgeqrf(context.cusolver_handle, A_copy.rows(), A_copy.columns(), A_copy.data(), A_copy.rows(), d_tau, d_work, work_size, d_dev_info));
 
-		tsvd_check(dev_info[0] == 0, "geqrf unsuccessful");
+		h2o4gpu_check(dev_info[0] == 0, "geqrf unsuccessful");
 
 		safe_cusolver(cusolverDnSormqr(context.cusolver_handle, CUBLAS_SIDE_LEFT, CUBLAS_OP_T, A.rows(), A.columns(), (std::min)(A.rows(), A.columns()), A_copy.data(), A.rows(), d_tau, B_copy.data(), A.rows(), d_work, work_size, d_dev_info));
-		tsvd_check(dev_info[0] == 0, "ormqr unsuccessful");
+		h2o4gpu_check(dev_info[0] == 0, "ormqr unsuccessful");
 
 		Matrix<tsvd_float> R(A.columns(), A.columns());
 		Matrix<tsvd_float> QTB(A.columns(), B.columns());
@@ -343,7 +343,7 @@ namespace tsvd
 
 	void pseudoinverse(const Matrix<tsvd_float>& A, Matrix<tsvd_float>& pinvA, DeviceContext& context)
 	{
-		tsvd_check(A.rows() == pinvA.columns() && A.columns() == pinvA.rows(), "pseudoinverse dimensions incorrect");
+		h2o4gpu_check(A.rows() == pinvA.columns() && A.columns() == pinvA.rows(), "pseudoinverse dimensions incorrect");
 
 		//Add zero rows if m < n such that m >= n
 		Matrix<tsvd_float> A_extended((std::max)(A.columns(), A.rows()), A.columns());

--- a/src/gpu/data/matrix.cuh
+++ b/src/gpu/data/matrix.cuh
@@ -6,7 +6,6 @@
 
 namespace tsvd
 {
-	using namespace device;
 	using namespace h2o4gpu;
 
 	typedef float  tsvd_float;
@@ -308,11 +307,11 @@ namespace tsvd
 		}
 	};
 
-	void multiply_diag(const Matrix<tsvd_float>& A, const Matrix<tsvd_float>& B, Matrix<tsvd_float>& C, DeviceContext& context, bool left_diag);
-	void multiply_diag(const Matrix<tsvd_double>& A, const Matrix<tsvd_double>& B, Matrix<tsvd_double>& C, DeviceContext& context, bool left_diag);
+	void multiply_diag(const Matrix<tsvd_float>& A, const Matrix<tsvd_float>& B, Matrix<tsvd_float>& C, device::DeviceContext& context, bool left_diag);
+	void multiply_diag(const Matrix<tsvd_double>& A, const Matrix<tsvd_double>& B, Matrix<tsvd_double>& C, device::DeviceContext& context, bool left_diag);
 
 	/**
-	 * \fn	void multiply(const Matrix<tsvd_float>& A, const Matrix<tsvd_float>& B, Matrix<tsvd_float>& C, DeviceContext& context, bool transpose_a = false, bool transpose_b = false, tsvd_float alpha=1.0f);
+	 * \fn	void multiply(const Matrix<tsvd_float>& A, const Matrix<tsvd_float>& B, Matrix<tsvd_float>& C, device::DeviceContext& context, bool transpose_a = false, bool transpose_b = false, tsvd_float alpha=1.0f);
 	 *
 	 * \brief	Matrix multiplication. ABa = C. A or B may be transposed. a is a scalar.
 	 *
@@ -325,10 +324,10 @@ namespace tsvd
 	 * \param 		  	alpha	   	(Optional) The alpha.
 	 */
 
-	void multiply(const Matrix<tsvd_float>& A, const Matrix<tsvd_float>& B, Matrix<tsvd_float>& C, DeviceContext& context, bool transpose_a = false, bool transpose_b = false, tsvd_float alpha = 1.0f);
+	void multiply(const Matrix<tsvd_float>& A, const Matrix<tsvd_float>& B, Matrix<tsvd_float>& C, device::DeviceContext& context, bool transpose_a = false, bool transpose_b = false, tsvd_float alpha = 1.0f);
 
 	/**
-	 * \fn	void multiply(const Matrix<tsvd_double>& A, const Matrix<tsvd_double>& B, Matrix<tsvd_double>& C, DeviceContext& context, bool transpose_a = false, bool transpose_b = false, tsvd_double alpha=1.0f);
+	 * \fn	void multiply(const Matrix<tsvd_double>& A, const Matrix<tsvd_double>& B, Matrix<tsvd_double>& C, device::DeviceContext& context, bool transpose_a = false, bool transpose_b = false, tsvd_double alpha=1.0f);
 	 *
 	 * \brief	Matrix multiplication. ABa = C. A or B may be transposed. a is a scalar.
 	 *
@@ -341,10 +340,10 @@ namespace tsvd
 	 * \param 		  	alpha	   	(Optional) The alpha.
 	 */
 
-	void multiply(const Matrix<tsvd_double>& A, const Matrix<tsvd_double>& B, Matrix<tsvd_double>& C, DeviceContext& context, bool transpose_a = false, bool transpose_b = false, tsvd_double alpha = 1.0f);
+	void multiply(const Matrix<tsvd_double>& A, const Matrix<tsvd_double>& B, Matrix<tsvd_double>& C, device::DeviceContext& context, bool transpose_a = false, bool transpose_b = false, tsvd_double alpha = 1.0f);
 
 	/**
-	 * \fn	void multiply(Matrix<tsvd_float>& A, const tsvd_float a ,DeviceContext& context);
+	 * \fn	void multiply(Matrix<tsvd_float>& A, const tsvd_float a ,device::DeviceContext& context);
 	 *
 	 * \brief	Matrix scalar multiplication.
 	 *
@@ -354,20 +353,20 @@ namespace tsvd
 	 */
 
 	template<typename T, typename U>
-	void multiply(Matrix<T>& A, const U a, DeviceContext& context);
+	void multiply(Matrix<T>& A, const U a, device::DeviceContext& context);
 
 	/**
-	 * \fn	void matrix_sub(const Matrix<tsvd_float>& A, const Matrix<float>& B, Matrix<float>& C, DeviceContext& context)
+	 * \fn	void matrix_sub(const Matrix<tsvd_float>& A, const Matrix<float>& B, Matrix<float>& C, device::DeviceContext& context)
 	 *
 	 * \brief	Matrix subtraction. A - B = C.
 	 *
 	 */
 
 	template<typename T>
-	void subtract(const Matrix<T>& A, const Matrix<T>& B, Matrix<T>& C, DeviceContext& context);
+	void subtract(const Matrix<T>& A, const Matrix<T>& B, Matrix<T>& C, device::DeviceContext& context);
 
 	/**
-	 * \fn	void add(const Matrix<tsvd_float>& A, const Matrix<tsvd_float>& B, Matrix<tsvd_float>& C, DeviceContext& context);
+	 * \fn	void add(const Matrix<tsvd_float>& A, const Matrix<tsvd_float>& B, Matrix<tsvd_float>& C, device::DeviceContext& context);
 	 *
 	 * \brief	Matrix addition. A + B = C	
 	 *
@@ -378,10 +377,10 @@ namespace tsvd
 	 */
 
 	template<typename T>
-	void add(const Matrix<T>& A, const Matrix<T>& B, Matrix<T>& C, DeviceContext& context);
+	void add(const Matrix<T>& A, const Matrix<T>& B, Matrix<T>& C, device::DeviceContext& context);
 
 	/**
-	 * \fn	void transpose(const Matrix<tsvd_float >&A, Matrix<tsvd_float >&B, DeviceContext& context)
+	 * \fn	void transpose(const Matrix<tsvd_float >&A, Matrix<tsvd_float >&B, device::DeviceContext& context)
 	 *
 	 * \brief	Transposes matrix A into matrix B.
 	 *
@@ -390,10 +389,10 @@ namespace tsvd
 	 * \param [in,out]	context	The context.
 	 */
 
-	void transpose(const Matrix<tsvd_float>& A, Matrix<tsvd_float>& B, DeviceContext& context);
+	void transpose(const Matrix<tsvd_float>& A, Matrix<tsvd_float>& B, device::DeviceContext& context);
 
 	/**
-	 * \fn	void transpose(const Matrix<tsvd_double >&A, Matrix<tsvd_double >&B, DeviceContext& context)
+	 * \fn	void transpose(const Matrix<tsvd_double >&A, Matrix<tsvd_double >&B, device::DeviceContext& context)
 	 *
 	 * \brief	Transposes matrix A into matrix B.
 	 *
@@ -402,10 +401,10 @@ namespace tsvd
 	 * \param [in,out]	context	The context.
 	 */
 
-	void transpose(const Matrix<tsvd_double>& A, Matrix<tsvd_double>& B, DeviceContext& context);
+	void transpose(const Matrix<tsvd_double>& A, Matrix<tsvd_double>& B, device::DeviceContext& context);
 
 	/**
-	 * \fn	void normalize_columns(Matrix<tsvd_float>& M, Matrix<tsvd_float>& M_temp, Matrix<tsvd_float>& column_length, Matrix<tsvd_float>& ones, DeviceContext& context);
+	 * \fn	void normalize_columns(Matrix<tsvd_float>& M, Matrix<tsvd_float>& M_temp, Matrix<tsvd_float>& column_length, Matrix<tsvd_float>& ones, device::DeviceContext& context);
 	 *
 	 * \brief	Normalize matrix columns.
 	 *
@@ -416,35 +415,35 @@ namespace tsvd
 	 * \param [in,out]	context		 	The context.
 	 */
 
-	void normalize_columns(Matrix<tsvd_float>& M, Matrix<tsvd_float>& M_temp, Matrix<tsvd_float>& column_length, const Matrix<tsvd_float>& ones, DeviceContext& context);
-	void normalize_columns(Matrix<tsvd_double>& M, Matrix<tsvd_double>& M_temp, Matrix<tsvd_double>& column_length, const Matrix<tsvd_double>& ones, DeviceContext& context);
+	void normalize_columns(Matrix<tsvd_float>& M, Matrix<tsvd_float>& M_temp, Matrix<tsvd_float>& column_length, const Matrix<tsvd_float>& ones, device::DeviceContext& context);
+	void normalize_columns(Matrix<tsvd_double>& M, Matrix<tsvd_double>& M_temp, Matrix<tsvd_double>& column_length, const Matrix<tsvd_double>& ones, device::DeviceContext& context);
 
-	void normalize_columns(Matrix<tsvd_float>& M, DeviceContext& context);
-	void normalize_columns(Matrix<tsvd_double>& M, DeviceContext& context);
+	void normalize_columns(Matrix<tsvd_float>& M, device::DeviceContext& context);
+	void normalize_columns(Matrix<tsvd_double>& M, device::DeviceContext& context);
 
 	/**
-	 * \fn	void normalize_vector_cublas(Matrix<tsvd_float>& M, DeviceContext& context)
+	 * \fn	void normalize_vector_cublas(Matrix<tsvd_float>& M, device::DeviceContext& context)
 	 *
 	 * \brief	Normalize a vector utilizing cuBLAS
 	 *
 	 * \param [in,out]	M	    The vector to process
 	 * \param [in,out]	context	Device context.
 	 */
-	void normalize_vector_cublas(Matrix<tsvd_float>& M, DeviceContext& context);
+	void normalize_vector_cublas(Matrix<tsvd_float>& M, device::DeviceContext& context);
 
 	/**
-	 * \fn	void normalize_vector_cublas(Matrix<tsvd_double>& M, DeviceContext& context)
+	 * \fn	void normalize_vector_cublas(Matrix<tsvd_double>& M, device::DeviceContext& context)
 	 *
 	 * \brief	Normalize a vector utilizing cuBLAS
 	 *
 	 * \param [in,out]	M	    The vector to process
 	 * \param [in,out]	context	Device context.
 	 */
-	void normalize_vector_cublas(Matrix<tsvd_double>& M, DeviceContext& context);
+	void normalize_vector_cublas(Matrix<tsvd_double>& M, device::DeviceContext& context);
 
 
 	/**
-	 * \fn	void normalize_vector_thrust(Matrix<tsvd_float>& M, DeviceContext& context)
+	 * \fn	void normalize_vector_thrust(Matrix<tsvd_float>& M, device::DeviceContext& context)
 	 *
 	 * \brief	Normalize a vector utilizng Thrust
 	 *
@@ -453,32 +452,32 @@ namespace tsvd
 	 */
 
 	template<typename T>
-	void normalize_vector_thrust(Matrix<T>& M, DeviceContext& context);
+	void normalize_vector_thrust(Matrix<T>& M, device::DeviceContext& context);
 
 	/**
-	 * \fn	void residual(const Matrix<tsvd_float >&X, const Matrix<tsvd_float >&D, const Matrix<tsvd_float >&S, Matrix<tsvd_float >&R, DeviceContext & context);
+	 * \fn	void residual(const Matrix<tsvd_float >&X, const Matrix<tsvd_float >&D, const Matrix<tsvd_float >&S, Matrix<tsvd_float >&R, device::DeviceContext & context);
 	 *
 	 * \brief	Calculate residual R = X - DS
 	 *
 	 */
 
-	void residual(const Matrix<tsvd_float>& X, const Matrix<tsvd_float>& D, const Matrix<tsvd_float>& S, Matrix<tsvd_float>& R, DeviceContext& context);
-	void residual(const Matrix<tsvd_double>& X, const Matrix<tsvd_double>& D, const Matrix<tsvd_double>& S, Matrix<tsvd_double>& R, DeviceContext& context);
+	void residual(const Matrix<tsvd_float>& X, const Matrix<tsvd_float>& D, const Matrix<tsvd_float>& S, Matrix<tsvd_float>& R, device::DeviceContext& context);
+	void residual(const Matrix<tsvd_double>& X, const Matrix<tsvd_double>& D, const Matrix<tsvd_double>& S, Matrix<tsvd_double>& R, device::DeviceContext& context);
 
-	void calculate_eigen_pairs_exact(const Matrix<tsvd_float>& X, Matrix<tsvd_float>& Q, Matrix<tsvd_float>& w, DeviceContext& context);
-	void calculate_eigen_pairs_exact(const Matrix<tsvd_double>& X, Matrix<tsvd_double>& Q, Matrix<tsvd_double>& w, DeviceContext& context);
+	void calculate_eigen_pairs_exact(const Matrix<tsvd_float>& X, Matrix<tsvd_float>& Q, Matrix<tsvd_float>& w, device::DeviceContext& context);
+	void calculate_eigen_pairs_exact(const Matrix<tsvd_double>& X, Matrix<tsvd_double>& Q, Matrix<tsvd_double>& w, device::DeviceContext& context);
 
-	void dot_product(Matrix<tsvd_float>& b_k1, Matrix<tsvd_float>& b_k, float* eigen_value_estimate, DeviceContext& context);
-	void dot_product(Matrix<tsvd_double>& b_k1, Matrix<tsvd_double>& b_k, double* eigen_value_estimate, DeviceContext& context);
+	void dot_product(Matrix<tsvd_float>& b_k1, Matrix<tsvd_float>& b_k, float* eigen_value_estimate, device::DeviceContext& context);
+	void dot_product(Matrix<tsvd_double>& b_k1, Matrix<tsvd_double>& b_k, double* eigen_value_estimate, device::DeviceContext& context);
 
-	void max_index_per_column(Matrix<tsvd_float>& A, std::vector<int>& result_array, DeviceContext& context);
-	void max_index_per_column(Matrix<tsvd_double>& A, std::vector<int>& result_array, DeviceContext& context);
+	void max_index_per_column(Matrix<tsvd_float>& A, std::vector<int>& result_array, device::DeviceContext& context);
+	void max_index_per_column(Matrix<tsvd_double>& A, std::vector<int>& result_array, device::DeviceContext& context);
 
 	//----------------------------------------------------------------------------------------------------------------------------------------------------------------------
 	//Stricly floating point operations that are not used
 
 	/**
-	 * \fn	void linear_solve(const Matrix<tsvd_float>& A, Matrix<tsvd_float>& X, const Matrix<tsvd_float>& B, DeviceContext& context)
+	 * \fn	void linear_solve(const Matrix<tsvd_float>& A, Matrix<tsvd_float>& X, const Matrix<tsvd_float>& B, device::DeviceContext& context)
 	 *
 	 * \brief	Solve linear system AX=B to find B.
 	 *
@@ -488,10 +487,10 @@ namespace tsvd
 	 * \param [in,out]	context	The context.
 	 */
 
-	void linear_solve(const Matrix<tsvd_float>& A, Matrix<tsvd_float>& X, const Matrix<tsvd_float>& B, DeviceContext& context);
+	void linear_solve(const Matrix<tsvd_float>& A, Matrix<tsvd_float>& X, const Matrix<tsvd_float>& B, device::DeviceContext& context);
 
 	/**
-	 * \fn	void pseudoinverse(const Matrix<tsvd_float>& A, Matrix<tsvd_float>& pinvA, DeviceContext& context)
+	 * \fn	void pseudoinverse(const Matrix<tsvd_float>& A, Matrix<tsvd_float>& pinvA, device::DeviceContext& context)
 	 *
 	 * \brief	Calculate Moore-Penrose seudoinverse using the singular value decomposition method.
 	 *
@@ -500,6 +499,6 @@ namespace tsvd
 	 * \param [in,out]	context	Device context.
 	 */
 
-	void pseudoinverse(const Matrix<tsvd_float>& A, Matrix<tsvd_float>& pinvA, DeviceContext& context);
+	void pseudoinverse(const Matrix<tsvd_float>& A, Matrix<tsvd_float>& pinvA, device::DeviceContext& context);
 
 }

--- a/src/gpu/data/matrix.cuh
+++ b/src/gpu/data/matrix.cuh
@@ -1,5 +1,5 @@
 #pragma once
-#include "../tsvd/utils.cuh"
+#include "../utils/utils.cuh"
 #include "../device/device_context.cuh"
 #include "cusolverDn.h"
 #include <../../../cub/cub/cub.cuh>
@@ -275,7 +275,7 @@ namespace tsvd
 
 		void copy(const Matrix<T>& M)
 		{
-			tsvd_check(M.rows() == this->rows()&&M.columns() == this->columns(), "Cannot copy matrix. Dimensions are different.");
+			h2o4gpu_check(M.rows() == this->rows()&&M.columns() == this->columns(), "Cannot copy matrix. Dimensions are different.");
 			thrust::copy(M.dptr(), M.dptr() + M.size(), this->dptr());
 		}
 

--- a/src/gpu/data/matrix.cuh
+++ b/src/gpu/data/matrix.cuh
@@ -4,12 +4,9 @@
 #include "cusolverDn.h"
 #include <../../../cub/cub/cub.cuh>
 
-namespace tsvd
+namespace matrix
 {
 	using namespace h2o4gpu;
-
-	typedef float  tsvd_float;
-	typedef double tsvd_double;
 
 	/**
 	 * \class	Matrix
@@ -283,12 +280,12 @@ namespace tsvd
 
 		void print() const
 		{
-			thrust::host_vector<T> h_tsvd(thrust::device_ptr<T>(_data), thrust::device_ptr<T>(_data + _n * _m));
+			thrust::host_vector<T> h_matrix(thrust::device_ptr<T>(_data), thrust::device_ptr<T>(_data + _n * _m));
 			for (auto i = 0; i < _m; i++)
 			{
 				for (auto j = 0; j < _n; j++)
 				{
-					printf("%1.2f ", h_tsvd[j * _m + i]);
+					printf("%1.2f ", h_matrix[j * _m + i]);
 				}
 				printf("\n");
 			}
@@ -307,16 +304,16 @@ namespace tsvd
 		}
 	};
 
-	void multiply_diag(const Matrix<tsvd_float>& A, const Matrix<tsvd_float>& B, Matrix<tsvd_float>& C, device::DeviceContext& context, bool left_diag);
-	void multiply_diag(const Matrix<tsvd_double>& A, const Matrix<tsvd_double>& B, Matrix<tsvd_double>& C, device::DeviceContext& context, bool left_diag);
+	void multiply_diag(const Matrix<float>& A, const Matrix<float>& B, Matrix<float>& C, device::DeviceContext& context, bool left_diag);
+	void multiply_diag(const Matrix<double>& A, const Matrix<double>& B, Matrix<double>& C, device::DeviceContext& context, bool left_diag);
 
 	/**
-	 * \fn	void multiply(const Matrix<tsvd_float>& A, const Matrix<tsvd_float>& B, Matrix<tsvd_float>& C, device::DeviceContext& context, bool transpose_a = false, bool transpose_b = false, tsvd_float alpha=1.0f);
+	 * \fn	void multiply(const Matrix<float>& A, const Matrix<float>& B, Matrix<float>& C, device::DeviceContext& context, bool transpose_a = false, bool transpose_b = false, float alpha=1.0f);
 	 *
 	 * \brief	Matrix multiplication. ABa = C. A or B may be transposed. a is a scalar.
 	 *
 	 * \param 		  	A		   	The Matrix&lt;float&gt; to process.
-	 * \param 		  	B		   	The Matrix&lt;tsvd_float&gt; to process.
+	 * \param 		  	B		   	The Matrix&lt;float&gt; to process.
 	 * \param [in,out]	C		   	The Matrix&lt;float&gt; to process.
 	 * \param [in,out]	context	   	The context.
 	 * \param 		  	transpose_a	(Optional) True to transpose a.
@@ -324,15 +321,15 @@ namespace tsvd
 	 * \param 		  	alpha	   	(Optional) The alpha.
 	 */
 
-	void multiply(const Matrix<tsvd_float>& A, const Matrix<tsvd_float>& B, Matrix<tsvd_float>& C, device::DeviceContext& context, bool transpose_a = false, bool transpose_b = false, tsvd_float alpha = 1.0f);
+	void multiply(const Matrix<float>& A, const Matrix<float>& B, Matrix<float>& C, device::DeviceContext& context, bool transpose_a = false, bool transpose_b = false, float alpha = 1.0f);
 
 	/**
-	 * \fn	void multiply(const Matrix<tsvd_double>& A, const Matrix<tsvd_double>& B, Matrix<tsvd_double>& C, device::DeviceContext& context, bool transpose_a = false, bool transpose_b = false, tsvd_double alpha=1.0f);
+	 * \fn	void multiply(const Matrix<double>& A, const Matrix<double>& B, Matrix<double>& C, device::DeviceContext& context, bool transpose_a = false, bool transpose_b = false, double alpha=1.0f);
 	 *
 	 * \brief	Matrix multiplication. ABa = C. A or B may be transposed. a is a scalar.
 	 *
 	 * \param 		  	A		   	The Matrix&lt;float&gt; to process.
-	 * \param 		  	B		   	The Matrix&lt;tsvd_double&gt; to process.
+	 * \param 		  	B		   	The Matrix&lt;double&gt; to process.
 	 * \param [in,out]	C		   	The Matrix&lt;float&gt; to process.
 	 * \param [in,out]	context	   	The context.
 	 * \param 		  	transpose_a	(Optional) True to transpose a.
@@ -340,10 +337,10 @@ namespace tsvd
 	 * \param 		  	alpha	   	(Optional) The alpha.
 	 */
 
-	void multiply(const Matrix<tsvd_double>& A, const Matrix<tsvd_double>& B, Matrix<tsvd_double>& C, device::DeviceContext& context, bool transpose_a = false, bool transpose_b = false, tsvd_double alpha = 1.0f);
+	void multiply(const Matrix<double>& A, const Matrix<double>& B, Matrix<double>& C, device::DeviceContext& context, bool transpose_a = false, bool transpose_b = false, double alpha = 1.0f);
 
 	/**
-	 * \fn	void multiply(Matrix<tsvd_float>& A, const tsvd_float a ,device::DeviceContext& context);
+	 * \fn	void multiply(Matrix<float>& A, const float a ,device::DeviceContext& context);
 	 *
 	 * \brief	Matrix scalar multiplication.
 	 *
@@ -356,7 +353,7 @@ namespace tsvd
 	void multiply(Matrix<T>& A, const U a, device::DeviceContext& context);
 
 	/**
-	 * \fn	void matrix_sub(const Matrix<tsvd_float>& A, const Matrix<float>& B, Matrix<float>& C, device::DeviceContext& context)
+	 * \fn	void matrix_sub(const Matrix<float>& A, const Matrix<float>& B, Matrix<float>& C, device::DeviceContext& context)
 	 *
 	 * \brief	Matrix subtraction. A - B = C.
 	 *
@@ -366,13 +363,13 @@ namespace tsvd
 	void subtract(const Matrix<T>& A, const Matrix<T>& B, Matrix<T>& C, device::DeviceContext& context);
 
 	/**
-	 * \fn	void add(const Matrix<tsvd_float>& A, const Matrix<tsvd_float>& B, Matrix<tsvd_float>& C, device::DeviceContext& context);
+	 * \fn	void add(const Matrix<float>& A, const Matrix<float>& B, Matrix<float>& C, device::DeviceContext& context);
 	 *
 	 * \brief	Matrix addition. A + B = C	
 	 *
-	 * \param 		  	A	   	The Matrix&lt;tsvd_float&gt; to process.
-	 * \param 		  	B	   	The Matrix&lt;tsvd_float&gt; to process.
-	 * \param [in,out]	C	   	The Matrix&lt;tsvd_float&gt; to process.
+	 * \param 		  	A	   	The Matrix&lt;float&gt; to process.
+	 * \param 		  	B	   	The Matrix&lt;float&gt; to process.
+	 * \param [in,out]	C	   	The Matrix&lt;float&gt; to process.
 	 * \param [in,out]	context	The context.
 	 */
 
@@ -380,70 +377,70 @@ namespace tsvd
 	void add(const Matrix<T>& A, const Matrix<T>& B, Matrix<T>& C, device::DeviceContext& context);
 
 	/**
-	 * \fn	void transpose(const Matrix<tsvd_float >&A, Matrix<tsvd_float >&B, device::DeviceContext& context)
+	 * \fn	void transpose(const Matrix<float >&A, Matrix<float >&B, device::DeviceContext& context)
 	 *
 	 * \brief	Transposes matrix A into matrix B.
 	 *
-	 * \param 		  	A	   	The Matrix&lt;tsvd_float&gt; to process.
-	 * \param [in,out]	B	   	The Matrix&lt;tsvd_float&gt; to process.
+	 * \param 		  	A	   	The Matrix&lt;float&gt; to process.
+	 * \param [in,out]	B	   	The Matrix&lt;float&gt; to process.
 	 * \param [in,out]	context	The context.
 	 */
 
-	void transpose(const Matrix<tsvd_float>& A, Matrix<tsvd_float>& B, device::DeviceContext& context);
+	void transpose(const Matrix<float>& A, Matrix<float>& B, device::DeviceContext& context);
 
 	/**
-	 * \fn	void transpose(const Matrix<tsvd_double >&A, Matrix<tsvd_double >&B, device::DeviceContext& context)
+	 * \fn	void transpose(const Matrix<double >&A, Matrix<double >&B, device::DeviceContext& context)
 	 *
 	 * \brief	Transposes matrix A into matrix B.
 	 *
-	 * \param 		  	A	   	The Matrix&lt;tsvd_double&gt; to process.
-	 * \param [in,out]	B	   	The Matrix&lt;tsvd_double&gt; to process.
+	 * \param 		  	A	   	The Matrix&lt;double&gt; to process.
+	 * \param [in,out]	B	   	The Matrix&lt;double&gt; to process.
 	 * \param [in,out]	context	The context.
 	 */
 
-	void transpose(const Matrix<tsvd_double>& A, Matrix<tsvd_double>& B, device::DeviceContext& context);
+	void transpose(const Matrix<double>& A, Matrix<double>& B, device::DeviceContext& context);
 
 	/**
-	 * \fn	void normalize_columns(Matrix<tsvd_float>& M, Matrix<tsvd_float>& M_temp, Matrix<tsvd_float>& column_length, Matrix<tsvd_float>& ones, device::DeviceContext& context);
+	 * \fn	void normalize_columns(Matrix<float>& M, Matrix<float>& M_temp, Matrix<float>& column_length, Matrix<float>& ones, device::DeviceContext& context);
 	 *
 	 * \brief	Normalize matrix columns.
 	 *
-	 * \param [in,out]	M			 	The Matrix&lt;tsvd_float&gt; to process.
+	 * \param [in,out]	M			 	The Matrix&lt;float&gt; to process.
 	 * \param [in,out]	M_temp		 	Temporary storage matrix of size >= M.
 	 * \param [in,out]	column_length	Temporary storage matrix with one element per column.
 	 * \param [in,out]	ones		 	Matrix of ones of length M.columns().
 	 * \param [in,out]	context		 	The context.
 	 */
 
-	void normalize_columns(Matrix<tsvd_float>& M, Matrix<tsvd_float>& M_temp, Matrix<tsvd_float>& column_length, const Matrix<tsvd_float>& ones, device::DeviceContext& context);
-	void normalize_columns(Matrix<tsvd_double>& M, Matrix<tsvd_double>& M_temp, Matrix<tsvd_double>& column_length, const Matrix<tsvd_double>& ones, device::DeviceContext& context);
+	void normalize_columns(Matrix<float>& M, Matrix<float>& M_temp, Matrix<float>& column_length, const Matrix<float>& ones, device::DeviceContext& context);
+	void normalize_columns(Matrix<double>& M, Matrix<double>& M_temp, Matrix<double>& column_length, const Matrix<double>& ones, device::DeviceContext& context);
 
-	void normalize_columns(Matrix<tsvd_float>& M, device::DeviceContext& context);
-	void normalize_columns(Matrix<tsvd_double>& M, device::DeviceContext& context);
+	void normalize_columns(Matrix<float>& M, device::DeviceContext& context);
+	void normalize_columns(Matrix<double>& M, device::DeviceContext& context);
 
 	/**
-	 * \fn	void normalize_vector_cublas(Matrix<tsvd_float>& M, device::DeviceContext& context)
+	 * \fn	void normalize_vector_cublas(Matrix<float>& M, device::DeviceContext& context)
 	 *
 	 * \brief	Normalize a vector utilizing cuBLAS
 	 *
 	 * \param [in,out]	M	    The vector to process
 	 * \param [in,out]	context	Device context.
 	 */
-	void normalize_vector_cublas(Matrix<tsvd_float>& M, device::DeviceContext& context);
+	void normalize_vector_cublas(Matrix<float>& M, device::DeviceContext& context);
 
 	/**
-	 * \fn	void normalize_vector_cublas(Matrix<tsvd_double>& M, device::DeviceContext& context)
+	 * \fn	void normalize_vector_cublas(Matrix<double>& M, device::DeviceContext& context)
 	 *
 	 * \brief	Normalize a vector utilizing cuBLAS
 	 *
 	 * \param [in,out]	M	    The vector to process
 	 * \param [in,out]	context	Device context.
 	 */
-	void normalize_vector_cublas(Matrix<tsvd_double>& M, device::DeviceContext& context);
+	void normalize_vector_cublas(Matrix<double>& M, device::DeviceContext& context);
 
 
 	/**
-	 * \fn	void normalize_vector_thrust(Matrix<tsvd_float>& M, device::DeviceContext& context)
+	 * \fn	void normalize_vector_thrust(Matrix<float>& M, device::DeviceContext& context)
 	 *
 	 * \brief	Normalize a vector utilizng Thrust
 	 *
@@ -455,42 +452,42 @@ namespace tsvd
 	void normalize_vector_thrust(Matrix<T>& M, device::DeviceContext& context);
 
 	/**
-	 * \fn	void residual(const Matrix<tsvd_float >&X, const Matrix<tsvd_float >&D, const Matrix<tsvd_float >&S, Matrix<tsvd_float >&R, device::DeviceContext & context);
+	 * \fn	void residual(const Matrix<float >&X, const Matrix<float >&D, const Matrix<float >&S, Matrix<float >&R, device::DeviceContext & context);
 	 *
 	 * \brief	Calculate residual R = X - DS
 	 *
 	 */
 
-	void residual(const Matrix<tsvd_float>& X, const Matrix<tsvd_float>& D, const Matrix<tsvd_float>& S, Matrix<tsvd_float>& R, device::DeviceContext& context);
-	void residual(const Matrix<tsvd_double>& X, const Matrix<tsvd_double>& D, const Matrix<tsvd_double>& S, Matrix<tsvd_double>& R, device::DeviceContext& context);
+	void residual(const Matrix<float>& X, const Matrix<float>& D, const Matrix<float>& S, Matrix<float>& R, device::DeviceContext& context);
+	void residual(const Matrix<double>& X, const Matrix<double>& D, const Matrix<double>& S, Matrix<double>& R, device::DeviceContext& context);
 
-	void calculate_eigen_pairs_exact(const Matrix<tsvd_float>& X, Matrix<tsvd_float>& Q, Matrix<tsvd_float>& w, device::DeviceContext& context);
-	void calculate_eigen_pairs_exact(const Matrix<tsvd_double>& X, Matrix<tsvd_double>& Q, Matrix<tsvd_double>& w, device::DeviceContext& context);
+	void calculate_eigen_pairs_exact(const Matrix<float>& X, Matrix<float>& Q, Matrix<float>& w, device::DeviceContext& context);
+	void calculate_eigen_pairs_exact(const Matrix<double>& X, Matrix<double>& Q, Matrix<double>& w, device::DeviceContext& context);
 
-	void dot_product(Matrix<tsvd_float>& b_k1, Matrix<tsvd_float>& b_k, float* eigen_value_estimate, device::DeviceContext& context);
-	void dot_product(Matrix<tsvd_double>& b_k1, Matrix<tsvd_double>& b_k, double* eigen_value_estimate, device::DeviceContext& context);
+	void dot_product(Matrix<float>& b_k1, Matrix<float>& b_k, float* eigen_value_estimate, device::DeviceContext& context);
+	void dot_product(Matrix<double>& b_k1, Matrix<double>& b_k, double* eigen_value_estimate, device::DeviceContext& context);
 
-	void max_index_per_column(Matrix<tsvd_float>& A, std::vector<int>& result_array, device::DeviceContext& context);
-	void max_index_per_column(Matrix<tsvd_double>& A, std::vector<int>& result_array, device::DeviceContext& context);
+	void max_index_per_column(Matrix<float>& A, std::vector<int>& result_array, device::DeviceContext& context);
+	void max_index_per_column(Matrix<double>& A, std::vector<int>& result_array, device::DeviceContext& context);
 
 	//----------------------------------------------------------------------------------------------------------------------------------------------------------------------
 	//Stricly floating point operations that are not used
 
 	/**
-	 * \fn	void linear_solve(const Matrix<tsvd_float>& A, Matrix<tsvd_float>& X, const Matrix<tsvd_float>& B, device::DeviceContext& context)
+	 * \fn	void linear_solve(const Matrix<float>& A, Matrix<float>& X, const Matrix<float>& B, device::DeviceContext& context)
 	 *
 	 * \brief	Solve linear system AX=B to find B.
 	 *
-	 * \param 		  	A	   	The Matrix&lt;tsvd_float&gt; to process.
-	 * \param [in,out]	X	   	The Matrix&lt;tsvd_float&gt; to process.
-	 * \param 		  	B	   	The Matrix&lt;tsvd_float&gt; to process.
+	 * \param 		  	A	   	The Matrix&lt;float&gt; to process.
+	 * \param [in,out]	X	   	The Matrix&lt;float&gt; to process.
+	 * \param 		  	B	   	The Matrix&lt;float&gt; to process.
 	 * \param [in,out]	context	The context.
 	 */
 
-	void linear_solve(const Matrix<tsvd_float>& A, Matrix<tsvd_float>& X, const Matrix<tsvd_float>& B, device::DeviceContext& context);
+	void linear_solve(const Matrix<float>& A, Matrix<float>& X, const Matrix<float>& B, device::DeviceContext& context);
 
 	/**
-	 * \fn	void pseudoinverse(const Matrix<tsvd_float>& A, Matrix<tsvd_float>& pinvA, device::DeviceContext& context)
+	 * \fn	void pseudoinverse(const Matrix<float>& A, Matrix<float>& pinvA, device::DeviceContext& context)
 	 *
 	 * \brief	Calculate Moore-Penrose seudoinverse using the singular value decomposition method.
 	 *
@@ -499,6 +496,6 @@ namespace tsvd
 	 * \param [in,out]	context	Device context.
 	 */
 
-	void pseudoinverse(const Matrix<tsvd_float>& A, Matrix<tsvd_float>& pinvA, device::DeviceContext& context);
+	void pseudoinverse(const Matrix<float>& A, Matrix<float>& pinvA, device::DeviceContext& context);
 
 }

--- a/src/gpu/data/matrix.cuh
+++ b/src/gpu/data/matrix.cuh
@@ -6,6 +6,8 @@
 
 namespace tsvd
 {
+	using namespace device;
+	using namespace h2o4gpu;
 
 	typedef float  tsvd_float;
 	typedef double tsvd_double;

--- a/src/gpu/device/device_context.cuh
+++ b/src/gpu/device/device_context.cuh
@@ -6,6 +6,8 @@
 
 namespace device
 {
+	using namespace h2o4gpu;
+
 	class DeviceContext
 	{
 	public:

--- a/src/gpu/device/device_context.cuh
+++ b/src/gpu/device/device_context.cuh
@@ -1,10 +1,10 @@
 #pragma once
 #include "cublas_v2.h"
-#include "../tsvd/utils.cuh"
+#include "../utils/utils.cuh"
 #include <cusparse.h>
 #include <cusolverDn.h>
 
-namespace tsvd
+namespace device
 {
 	class DeviceContext
 	{
@@ -12,7 +12,7 @@ namespace tsvd
 		cublasHandle_t cublas_handle;
 		cusolverDnHandle_t cusolver_handle;
 		cusparseHandle_t cusparse_handle;
-		CubMemory cub_mem;
+		h2o4gpu::CubMemory cub_mem;
 
 		DeviceContext()
 		{

--- a/src/gpu/pca/pca.cu
+++ b/src/gpu/pca/pca.cu
@@ -6,6 +6,8 @@
 
 namespace pca
 {
+	using namespace device;
+	using namespace h2o4gpu;
 
 	/**
 	* Conduct PCA on a matrix
@@ -22,7 +24,7 @@ namespace pca
 	void pca_float(const float *_X, float *_Q, float *_w, float *_U, float* _X_transformed, float *_explained_variance, float *_explained_variance_ratio, float *_mean, params _param) {
 		try {
 
-			tsvd::safe_cuda(cudaSetDevice(_param.gpu_id));
+			safe_cuda(cudaSetDevice(_param.gpu_id));
 
 			//Take in X matrix and allocate for X^TX
 			tsvd::Matrix<float>X(_param.X_m, _param.X_n);
@@ -31,7 +33,7 @@ namespace pca
 			tsvd::Matrix<float>XtX(_param.X_n, _param.X_n);
 
 			//create context
-			tsvd::DeviceContext context;
+			DeviceContext context;
 
 			//Get columnar means
 			tsvd::Matrix<float>XOnes(X.rows(), 1);
@@ -76,7 +78,7 @@ namespace pca
 	void pca_double(const double *_X, double *_Q, double *_w, double *_U, double* _X_transformed, double *_explained_variance, double *_explained_variance_ratio, double *_mean, params _param) {
 		try {
 
-			tsvd::safe_cuda(cudaSetDevice(_param.gpu_id));
+			safe_cuda(cudaSetDevice(_param.gpu_id));
 
 			//Take in X matrix and allocate for X^TX
 			tsvd::Matrix<double>X(_param.X_m, _param.X_n);
@@ -85,7 +87,7 @@ namespace pca
 			tsvd::Matrix<double>XtX(_param.X_n, _param.X_n);
 
 			//create context
-			tsvd::DeviceContext context;
+			DeviceContext context;
 
 			//Get columnar means
 			tsvd::Matrix<double>XOnes(X.rows(), 1);

--- a/src/gpu/pca/pca.cu
+++ b/src/gpu/pca/pca.cu
@@ -1,5 +1,5 @@
 #include "../../include/solver/pca.h"
-#include "../tsvd/utils.cuh"
+#include "../utils/utils.cuh"
 #include "../data/matrix.cuh"
 #include "../device/device_context.cuh"
 #include "../../include/solver/tsvd.h"

--- a/src/gpu/pca/pca.cu
+++ b/src/gpu/pca/pca.cu
@@ -26,28 +26,28 @@ namespace pca
 			safe_cuda(cudaSetDevice(_param.gpu_id));
 
 			//Take in X matrix and allocate for X^TX
-			tsvd::Matrix<float>X(_param.X_m, _param.X_n);
+			matrix::Matrix<float>X(_param.X_m, _param.X_n);
 			X.copy(_X);
 
-			tsvd::Matrix<float>XtX(_param.X_n, _param.X_n);
+			matrix::Matrix<float>XtX(_param.X_n, _param.X_n);
 
 			//create context
 			device::DeviceContext context;
 
 			//Get columnar means
-			tsvd::Matrix<float>XOnes(X.rows(), 1);
+			matrix::Matrix<float>XOnes(X.rows(), 1);
 			XOnes.fill(1.0f);
-			tsvd::Matrix<float>XColMean(X.columns(), 1);
-			tsvd::multiply(X, XOnes, XColMean, context, true, false, 1.0f);
+			matrix::Matrix<float>XColMean(X.columns(), 1);
+			matrix:multiply(X, XOnes, XColMean, context, true, false, 1.0f);
 			float m = X.rows();
 			multiply(XColMean, 1/m, context);
 			XColMean.copy_to_host(_mean);
 
 			//Center matrix
-			tsvd::Matrix<float>OnesXMeanTranspose(X.rows(), X.columns());
-			tsvd::multiply(XOnes, XColMean, OnesXMeanTranspose, context, false, true, 1.0f);
-			tsvd::Matrix<float>XCentered(X.rows(), X.columns());
-			tsvd::subtract(X, OnesXMeanTranspose, XCentered, context);
+			matrix::Matrix<float>OnesXMeanTranspose(X.rows(), X.columns());
+			matrix::multiply(XOnes, XColMean, OnesXMeanTranspose, context, false, true, 1.0f);
+			matrix::Matrix<float>XCentered(X.rows(), X.columns());
+			matrix::subtract(X, OnesXMeanTranspose, XCentered, context);
 
 			tsvd::params svd_param = {_param.X_n, _param.X_m, _param.k, _param.algorithm, _param.n_iter, _param.random_state, _param.tol, _param.verbose, _param.gpu_id, _param.whiten};
 
@@ -80,28 +80,28 @@ namespace pca
 			safe_cuda(cudaSetDevice(_param.gpu_id));
 
 			//Take in X matrix and allocate for X^TX
-			tsvd::Matrix<double>X(_param.X_m, _param.X_n);
+			matrix::Matrix<double>X(_param.X_m, _param.X_n);
 			X.copy(_X);
 
-			tsvd::Matrix<double>XtX(_param.X_n, _param.X_n);
+			matrix::Matrix<double>XtX(_param.X_n, _param.X_n);
 
 			//create context
 			device::DeviceContext context;
 
 			//Get columnar means
-			tsvd::Matrix<double>XOnes(X.rows(), 1);
+			matrix::Matrix<double>XOnes(X.rows(), 1);
 			XOnes.fill(1.0f);
-			tsvd::Matrix<double>XColMean(X.columns(), 1);
-			tsvd::multiply(X, XOnes, XColMean, context, true, false, 1.0f);
+			matrix::Matrix<double>XColMean(X.columns(), 1);
+			matrix::multiply(X, XOnes, XColMean, context, true, false, 1.0f);
 			float m = X.rows();
 			multiply(XColMean, 1/m, context);
 			XColMean.copy_to_host(_mean);
 
 			//Center matrix
-			tsvd::Matrix<double>OnesXMeanTranspose(X.rows(), X.columns());
-			tsvd::multiply(XOnes, XColMean, OnesXMeanTranspose, context, false, true, 1.0f);
-			tsvd::Matrix<double>XCentered(X.rows(), X.columns());
-			tsvd::subtract(X, OnesXMeanTranspose, XCentered, context);
+			matrix::Matrix<double>OnesXMeanTranspose(X.rows(), X.columns());
+			matrix::multiply(XOnes, XColMean, OnesXMeanTranspose, context, false, true, 1.0f);
+			matrix::Matrix<double>XCentered(X.rows(), X.columns());
+			matrix::subtract(X, OnesXMeanTranspose, XCentered, context);
 
 			tsvd::params svd_param = {_param.X_n, _param.X_m, _param.k, _param.algorithm, _param.n_iter, _param.random_state, _param.tol, _param.verbose, _param.gpu_id, _param.whiten};
 

--- a/src/gpu/pca/pca.cu
+++ b/src/gpu/pca/pca.cu
@@ -6,7 +6,6 @@
 
 namespace pca
 {
-	using namespace device;
 	using namespace h2o4gpu;
 
 	/**
@@ -33,7 +32,7 @@ namespace pca
 			tsvd::Matrix<float>XtX(_param.X_n, _param.X_n);
 
 			//create context
-			DeviceContext context;
+			device::DeviceContext context;
 
 			//Get columnar means
 			tsvd::Matrix<float>XOnes(X.rows(), 1);
@@ -87,7 +86,7 @@ namespace pca
 			tsvd::Matrix<double>XtX(_param.X_n, _param.X_n);
 
 			//create context
-			DeviceContext context;
+			device::DeviceContext context;
 
 			//Get columnar means
 			tsvd::Matrix<double>XOnes(X.rows(), 1);

--- a/src/gpu/tsvd/tsvd.cu
+++ b/src/gpu/tsvd/tsvd.cu
@@ -15,7 +15,6 @@ namespace tsvd
 {
 
 	using namespace h2o4gpu;
-	using namespace device;
 
 	/**
 	 * Division utility to get explained variance ratio
@@ -26,7 +25,7 @@ namespace tsvd
 	 * @param context
 	 */
 	template<typename T>
-	void divide(const Matrix<T> &XVar, const Matrix<T> &XVarSum, Matrix<T> &ExplainedVarRatio, DeviceContext &context){
+	void divide(const Matrix<T> &XVar, const Matrix<T> &XVarSum, Matrix<T> &ExplainedVarRatio, device::DeviceContext &context){
 		auto d_x_var = XVar.data();
 		auto d_x_var_sum = XVarSum.data();
 		auto d_expl_var_ratio = ExplainedVarRatio.data();
@@ -49,7 +48,7 @@ namespace tsvd
 	 * @param context
 	 */
 	template<typename T>
-	void square_val(const Matrix<T> &UmultSigma, Matrix<T> &UmultSigmaSquare, DeviceContext &context){
+	void square_val(const Matrix<T> &UmultSigma, Matrix<T> &UmultSigmaSquare, device::DeviceContext &context){
 		auto n = UmultSigma.columns();
 		auto m = UmultSigma.rows();
 		auto k = UmultSigmaSquare.rows();
@@ -71,7 +70,7 @@ namespace tsvd
 	 * @param context
 	 */
 	template<typename T>
-	void calc_var_numerator(Matrix<T> &X, const Matrix<T> &UColMean, Matrix<T> &UVar, DeviceContext &context){
+	void calc_var_numerator(Matrix<T> &X, const Matrix<T> &UColMean, Matrix<T> &UVar, device::DeviceContext &context){
 		auto counting = thrust::make_counting_iterator(0);
 		auto d_X = X.data();
 		auto d_Mean = UColMean.data();
@@ -96,7 +95,7 @@ namespace tsvd
 	 * @param context
 	 */
 	template<typename T>
-	void col_reverse_q(const Matrix<T> &Q, Matrix<T> &QReversed, DeviceContext &context){
+	void col_reverse_q(const Matrix<T> &Q, Matrix<T> &QReversed, device::DeviceContext &context){
 		auto n = Q.columns();
 		auto m = Q.rows();
 		auto k = QReversed.rows();
@@ -120,7 +119,7 @@ namespace tsvd
 	 * @param context
 	 */
 	template<typename T>
-	void row_reverse_trunc_q(const Matrix<T> &Qt, Matrix<T> &QtTrunc, DeviceContext &context){
+	void row_reverse_trunc_q(const Matrix<T> &Qt, Matrix<T> &QtTrunc, device::DeviceContext &context){
 		auto m = Qt.rows();
 		auto k = QtTrunc.rows();
 		auto d_q = Qt.data();
@@ -144,7 +143,7 @@ namespace tsvd
 	 * @param context
 	 */
 	template<typename T>
-	void get_abs(const Matrix<T> &U, Matrix<T> &U_abs, DeviceContext &context){
+	void get_abs(const Matrix<T> &U, Matrix<T> &U_abs, device::DeviceContext &context){
 		thrust::transform(U.dptr(), U.dptr() + U.size(), U_abs.dptr(), [=]__device__(T val){
             return abs(val);
         });
@@ -161,7 +160,7 @@ namespace tsvd
 	 * @param context
 	 */
 	template<typename T>
-	void calculate_u(const Matrix<T> &X, const Matrix<T> &Q, const Matrix<T> &w, Matrix<T> &U, DeviceContext &context){
+	void calculate_u(const Matrix<T> &X, const Matrix<T> &Q, const Matrix<T> &w, Matrix<T> &U, device::DeviceContext &context){
 		multiply(X, Q, U, context, false, false, 1.0f); //A*V
 		auto d_u = U.data();
 		auto d_sigma = w.data();
@@ -187,7 +186,7 @@ namespace tsvd
 	 * 4.Explained Variance Ratio
 	 */
 	template<typename T, typename S>
-	void get_tsvd_attr(Matrix<T> &X, Matrix<T> &Q, S _Q, Matrix<T> &w, S _w, S _U, S _X_transformed, S _explained_variance, S _explained_variance_ratio, params _param, DeviceContext &context){
+	void get_tsvd_attr(Matrix<T> &X, Matrix<T> &Q, S _Q, Matrix<T> &w, S _w, S _U, S _X_transformed, S _explained_variance, S _explained_variance_ratio, params _param, device::DeviceContext &context){
 
 		//Obtain Q^T to obtain vector as row major order
 		Matrix<T>Qt(Q.columns(), Q.rows());
@@ -294,12 +293,12 @@ namespace tsvd
 	}
 
 
-	void outer_product(Matrix<float>& A, float eigen_value, const Matrix<float>& eigen_vector, const Matrix<float>& eigen_vector_transpose, DeviceContext& context)
+	void outer_product(Matrix<float>& A, float eigen_value, const Matrix<float>& eigen_vector, const Matrix<float>& eigen_vector_transpose, device::DeviceContext& context)
 	{
 		safe_cublas(cublasSger(context.cublas_handle, A.rows(), A.columns(), &eigen_value, eigen_vector.data(), 1, eigen_vector_transpose.data(), 1, A.data(), A.rows()));
 	}
 
-	void outer_product(Matrix<double>& A, double eigen_value, const Matrix<double>& eigen_vector, const Matrix<double>& eigen_vector_transpose, DeviceContext& context)
+	void outer_product(Matrix<double>& A, double eigen_value, const Matrix<double>& eigen_vector, const Matrix<double>& eigen_vector_transpose, device::DeviceContext& context)
 	{
 		safe_cublas(cublasDger(context.cublas_handle, A.rows(), A.columns(), &eigen_value, eigen_vector.data(), 1, eigen_vector_transpose.data(), 1, A.data(), A.rows()));
 	}
@@ -321,7 +320,7 @@ namespace tsvd
 		Matrix<T>XtX(_param.X_n, _param.X_n);
 
 		//Create context
-		DeviceContext context;
+		device::DeviceContext context;
 
 		//Multiply X and Xt and output result to XtX
 		multiply(X, X, XtX, context, true, false, 1.0f);
@@ -355,7 +354,7 @@ namespace tsvd
 		Matrix<T>A(M.rows(), M.columns());
 
 		//Create context
-		DeviceContext context;
+		device::DeviceContext context;
 
 		//Multiply X and Xt and output result to XtX
 		multiply(X, X, M, context, true, false, 1.0f);

--- a/src/gpu/tsvd/tsvd.cu
+++ b/src/gpu/tsvd/tsvd.cu
@@ -1,6 +1,6 @@
 #include <cstdio>
 #include "cuda_runtime.h"
-#include "utils.cuh"
+#include "../utils/utils.cuh"
 #include "../device/device_context.cuh"
 #include "../../include/solver/tsvd.h"
 #include <ctime>

--- a/src/gpu/tsvd/tsvd.cu
+++ b/src/gpu/tsvd/tsvd.cu
@@ -14,6 +14,9 @@
 namespace tsvd
 {
 
+	using namespace h2o4gpu;
+	using namespace device;
+
 	/**
 	 * Division utility to get explained variance ratio
 	 *

--- a/src/gpu/utils/utils.cuh
+++ b/src/gpu/utils/utils.cuh
@@ -9,7 +9,6 @@
 #include <ctime>
 #include <cusparse.h>
 
-// TODO change this to h2o4gpu and move to gpu folder
 namespace h2o4gpu
 {
 #define h2o4gpu_error(x) error(x, __FILE__, __LINE__);

--- a/src/gpu/utils/utils.cuh
+++ b/src/gpu/utils/utils.cuh
@@ -10,9 +10,9 @@
 #include <cusparse.h>
 
 // TODO change this to h2o4gpu and move to gpu folder
-namespace tsvd
+namespace h2o4gpu
 {
-#define tsvd_error(x) error(x, __FILE__, __LINE__);
+#define h2o4gpu_error(x) error(x, __FILE__, __LINE__);
 
 	inline void error(const char* e, const char* file, int line)
 	{
@@ -23,7 +23,7 @@ namespace tsvd
 		exit(-1);
 	}
 
-#define tsvd_check(condition, msg) check(condition, msg, __FILE__, __LINE__);
+#define h2o4gpu_check(condition, msg) check(condition, msg, __FILE__, __LINE__);
 
 	inline void check(bool val, const char* e, const char* file, int line)
 	{

--- a/src/include/solver/tsvd.h
+++ b/src/include/solver/tsvd.h
@@ -6,12 +6,19 @@
 #define tsvd_export
 #endif
 
-namespace tsvd {
+namespace matrix {
 
-template <typename T>
+template<typename T>
 class Matrix;
 
+}
+
+namespace device {
 class DeviceContext;
+
+}
+
+namespace tsvd {
 
 typedef struct params {
   int X_n;
@@ -41,12 +48,12 @@ tsvd_export void truncated_svd_float(const float *_X, float *_Q, float *_w, floa
 tsvd_export void truncated_svd_double(const double *_X, double *_Q, double *_w, double *_U, double *_X_transformed, double *_explained_variance, double *_explained_variance_ratio, params _param);
 
 template<typename T, typename S>
-void cusolver_tsvd(Matrix<T> &X, S _Q, S _w, S _U, S _X_transformed, S _explained_variance, S _explained_variance_ratio, params _param);
+void cusolver_tsvd(matrix::Matrix<T> &X, S _Q, S _w, S _U, S _X_transformed, S _explained_variance, S _explained_variance_ratio, params _param);
 
 template<typename T, typename S>
-void power_tsvd(Matrix<T> &X, S _Q, S _w, S _U, S _X_transformed, S _explained_variance, S _explained_variance_ratio, params _param);
+void power_tsvd(matrix::Matrix<T> &X, S _Q, S _w, S _U, S _X_transformed, S _explained_variance, S _explained_variance_ratio, params _param);
 
 template<typename T, typename S>
-tsvd_export void truncated_svd_matrix(Matrix<T> &X, S _Q, S _w, S _U, S _X_transformed, S _explained_variance, S _explained_variance_ratio, params _param);
+tsvd_export void truncated_svd_matrix(matrix::Matrix<T> &X, S _Q, S _w, S _U, S _X_transformed, S _explained_variance, S _explained_variance_ratio, params _param);
 
 }


### PR DESCRIPTION
* Changed `Matrix` namespace from `tsvd` to `matrix`
* Changed DeviceContext namespace to `device`
* Moved `util.cu` from `tsvd/` to `src/gpu/utils` and changed namespace to `h2o4gpu`
* Removed use of `typedef` in Matrix class and opted to just use `float` and `double`
