### PR TITLE
Update license headers

### DIFF
--- a/examples/py/demos/H2O4GPU_Daal_LinearRegression.ipynb
+++ b/examples/py/demos/H2O4GPU_Daal_LinearRegression.ipynb
@@ -9,7 +9,7 @@
     "print(__doc__)\n",
     "%matplotlib inline\n",
     "\"\"\"\n",
-    ":copyright: 2017 H2O.ai, Inc.\n",
+    ":copyright: 2017-2018 H2O.ai, Inc.\n",
     ":license:   Apache License Version 2.0 (see LICENSE for details)\n",
     "\"\"\"\n",
     "import matplotlib\n",

--- a/src/common/elastic_net_ptr.cpp
+++ b/src/common/elastic_net_ptr.cpp
@@ -1,5 +1,5 @@
 /*!
- * Copyright 2017 H2O.ai, Inc.
+ * Copyright 2017-2018 H2O.ai, Inc.
  * License   Apache License Version 2.0 (see LICENSE for details)
  */
 #include "elastic_net_ptr.h"

--- a/src/common/elastic_net_ptr.h
+++ b/src/common/elastic_net_ptr.h
@@ -1,5 +1,5 @@
 /*!
- * Copyright 2017 H2O.ai, Inc.
+ * Copyright 2017-2018 H2O.ai, Inc.
  * License   Apache License Version 2.0 (see LICENSE for details)
  */
 #pragma once

--- a/src/common/logger.cpp
+++ b/src/common/logger.cpp
@@ -1,5 +1,5 @@
 /*!
- * Copyright 2017 H2O.ai, Inc.
+ * Copyright 2017-2018 H2O.ai, Inc.
  * License   Apache License Version 2.0 (see LICENSE for details)
  */
 #include "logger.h"

--- a/src/common/logger.h
+++ b/src/common/logger.h
@@ -1,5 +1,5 @@
 /*!
- * Copyright 2017 H2O.ai, Inc.
+ * Copyright 2017-2018 H2O.ai, Inc.
  * License   Apache License Version 2.0 (see LICENSE for details)
  */
 #pragma once

--- a/src/common/utils.cpp
+++ b/src/common/utils.cpp
@@ -1,5 +1,5 @@
 /**
- * Copyright 2017 H2O.ai, Inc.
+ * Copyright 2017-2018 H2O.ai, Inc.
  * License   Apache License Version 2.0 (see LICENSE for details)
  */
 #include "utils.h"

--- a/src/common/utils.h
+++ b/src/common/utils.h
@@ -1,5 +1,5 @@
 /*!
- * Copyright 2017 H2O.ai, Inc.
+ * Copyright 2017-2018 H2O.ai, Inc.
  * License   Apache License Version 2.0 (see LICENSE for details)
  */
 #pragma once

--- a/src/cpu/h2o4gpuglm.cpp
+++ b/src/cpu/h2o4gpuglm.cpp
@@ -1,5 +1,5 @@
 /*!
- * Modifications Copyright 2017 H2O.ai, Inc.
+ * Modifications Copyright 2017-2018 H2O.ai, Inc.
  */
 #include "solver/glm.h"
 

--- a/src/cpu/h2o4gpukmeans.cpp
+++ b/src/cpu/h2o4gpukmeans.cpp
@@ -1,5 +1,5 @@
 /*!
- * Modifications Copyright 2017 H2O.ai, Inc.
+ * Modifications Copyright 2017-2018 H2O.ai, Inc.
  */
 #include "matrix/matrix.h"
 #include "matrix/matrix_dense.h"

--- a/src/cpu/h2o4gpukmeans_kmeanscpu.h
+++ b/src/cpu/h2o4gpukmeans_kmeanscpu.h
@@ -1,5 +1,5 @@
 /*!
- * Modifications Copyright 2017 H2O.ai, Inc.
+ * Modifications Copyright 2017-2018 H2O.ai, Inc.
  */
 #define MAX_NCPUS 1
 

--- a/src/cpu/include/cgls.h
+++ b/src/cpu/include/cgls.h
@@ -1,5 +1,5 @@
 /*!
- * Modifications Copyright 2017 H2O.ai, Inc.
+ * Modifications Copyright 2017-2018 H2O.ai, Inc.
  */
 ////////////////////////////////////////////////////////////////////////////////
 // Copyright (c) 2015, Christopher Fougner                                    //

--- a/src/cpu/include/equil_helper.h
+++ b/src/cpu/include/equil_helper.h
@@ -1,5 +1,5 @@
 /*!
- * Modifications Copyright 2017 H2O.ai, Inc.
+ * Modifications Copyright 2017-2018 H2O.ai, Inc.
  */
 #ifndef EQUIL_HELPER_H_
 #define EQUIL_HELPER_H_

--- a/src/cpu/include/projector_helper.h
+++ b/src/cpu/include/projector_helper.h
@@ -1,5 +1,5 @@
 /*!
- * Modifications Copyright 2017 H2O.ai, Inc.
+ * Modifications Copyright 2017-2018 H2O.ai, Inc.
  */
 #ifndef PROJECTOR_HELPER_H_
 #define PROJECTOR_HELPER_H_

--- a/src/cpu/matrix/matrix_dense.cpp
+++ b/src/cpu/matrix/matrix_dense.cpp
@@ -1,5 +1,5 @@
 /*!
- * Modifications Copyright 2017 H2O.ai, Inc.
+ * Modifications Copyright 2017-2018 H2O.ai, Inc.
  */
 #include <iostream>
 #include <chrono>

--- a/src/cpu/matrix/matrix_sparse.cpp
+++ b/src/cpu/matrix/matrix_sparse.cpp
@@ -1,5 +1,5 @@
 /*!
- * Modifications Copyright 2017 H2O.ai, Inc.
+ * Modifications Copyright 2017-2018 H2O.ai, Inc.
  */
 #include "gsl/gsl_spblas.h"
 #include "gsl/gsl_spmat.h"

--- a/src/cpu/projector/projector_cgls.cpp
+++ b/src/cpu/projector/projector_cgls.cpp
@@ -1,5 +1,5 @@
 /*!
- * Modifications Copyright 2017 H2O.ai, Inc.
+ * Modifications Copyright 2017-2018 H2O.ai, Inc.
  */
 #include <algorithm>
 #include <limits>

--- a/src/cpu/projector/projector_direct_dense.cpp
+++ b/src/cpu/projector/projector_direct_dense.cpp
@@ -1,5 +1,5 @@
 /*!
- * Modifications Copyright 2017 H2O.ai, Inc.
+ * Modifications Copyright 2017-2018 H2O.ai, Inc.
  */
 #include <algorithm>
 #include <cstring>

--- a/src/gpu/bwcheck.cu
+++ b/src/gpu/bwcheck.cu
@@ -7,7 +7,7 @@
  * this software and related documentation outside the terms of the EULA
  * is strictly prohibited.
  *
- * Modifications Copyright 2017 H2O.ai, Inc.
+ * Modifications Copyright 2017-2018 H2O.ai, Inc.
  */
 /*
  * This is a simple test program to measure the memcopy bandwidth of the GPU.

--- a/src/gpu/h2o4gpuglm.cu
+++ b/src/gpu/h2o4gpuglm.cu
@@ -1,5 +1,5 @@
 /*!
- * Modifications Copyright 2017 H2O.ai, Inc.
+ * Modifications Copyright 2017-2018 H2O.ai, Inc.
  */
 #include "solver/glm.h"
 #include <stdio.h>

--- a/src/gpu/include/cgls.cuh
+++ b/src/gpu/include/cgls.cuh
@@ -1,5 +1,5 @@
 /*!
- * Modifications Copyright 2017 H2O.ai, Inc.
+ * Modifications Copyright 2017-2018 H2O.ai, Inc.
  */
 ////////////////////////////////////////////////////////////////////////////////
 // Copyright (c) 2015, Christopher Fougner                                    //

--- a/src/gpu/include/cuda_utils.h
+++ b/src/gpu/include/cuda_utils.h
@@ -1,5 +1,5 @@
 /*!
- * Modifications Copyright 2017 H2O.ai, Inc.
+ * Modifications Copyright 2017-2018 H2O.ai, Inc.
  */
 #ifndef _CUDA_UTILS_H
 #define _CUDA_UTILS_H

--- a/src/gpu/include/cuda_utils2.h
+++ b/src/gpu/include/cuda_utils2.h
@@ -1,5 +1,5 @@
 /*!
- * Modifications Copyright 2017 H2O.ai, Inc.
+ * Modifications Copyright 2017-2018 H2O.ai, Inc.
  */
 #ifndef _CUDA_UTILS2_H
 #define _CUDA_UTILS2_H

--- a/src/gpu/include/equil_helper.cuh
+++ b/src/gpu/include/equil_helper.cuh
@@ -1,5 +1,5 @@
 /*!
- * Modifications Copyright 2017 H2O.ai, Inc.
+ * Modifications Copyright 2017-2018 H2O.ai, Inc.
  */
 #ifndef EQUIL_HELPER_CUH_
 #define EQUIL_HELPER_CUH_

--- a/src/gpu/include/projector_helper.cuh
+++ b/src/gpu/include/projector_helper.cuh
@@ -1,5 +1,5 @@
 /*!
- * Modifications Copyright 2017 H2O.ai, Inc.
+ * Modifications Copyright 2017-2018 H2O.ai, Inc.
  */
 #ifndef PROJECTOR_HELPER_CUH_
 #define PROJECTOR_HELPER_CUH_

--- a/src/gpu/include/test_utilities.h
+++ b/src/gpu/include/test_utilities.h
@@ -3,7 +3,7 @@
  *
  * See LICENCE.txt for license information
  *
- * Modifications Copyright 2017 H2O.ai, Inc.
+ * Modifications Copyright 2017-2018 H2O.ai, Inc.
  ************************************************************************/
 #ifndef SRC_TEST_UTILITIES_H_
 #define SRC_TEST_UTILITIES_H_

--- a/src/gpu/kmeans/kmeans_centroids.h
+++ b/src/gpu/kmeans/kmeans_centroids.h
@@ -1,5 +1,5 @@
 /*!
- * Modifications Copyright 2017 H2O.ai, Inc.
+ * Modifications Copyright 2017-2018 H2O.ai, Inc.
  */
 // original code from https://github.com/NVIDIA/kmeans (Apache V2.0 License)
 #pragma once

--- a/src/gpu/kmeans/kmeans_general.h
+++ b/src/gpu/kmeans/kmeans_general.h
@@ -1,5 +1,5 @@
 /*!
- * Copyright 2017 H2O.ai, Inc.
+ * Copyright 2017-2018 H2O.ai, Inc.
  * License   Apache License Version 2.0 (see LICENSE for details)
  */
 #pragma once

--- a/src/gpu/kmeans/kmeans_h2o4gpu.cu
+++ b/src/gpu/kmeans/kmeans_h2o4gpu.cu
@@ -1,5 +1,5 @@
 /*!
- * Copyright 2017 H2O.ai, Inc.
+ * Copyright 2017-2018 H2O.ai, Inc.
  * License   Apache License Version 2.0 (see LICENSE for details)
  */
 #include <thrust/copy.h>

--- a/src/gpu/kmeans/kmeans_h2o4gpu.h
+++ b/src/gpu/kmeans/kmeans_h2o4gpu.h
@@ -1,5 +1,5 @@
 /*!
- * Copyright 2017 H2O.ai, Inc.
+ * Copyright 2017-2018 H2O.ai, Inc.
  * License   Apache License Version 2.0 (see LICENSE for details)
  */
 #pragma once

--- a/src/gpu/kmeans/kmeans_impl.h
+++ b/src/gpu/kmeans/kmeans_impl.h
@@ -1,5 +1,5 @@
 /*!
- * Modifications Copyright 2017 H2O.ai, Inc.
+ * Modifications Copyright 2017-2018 H2O.ai, Inc.
  */
 // original code from https://github.com/NVIDIA/kmeans (Apache V2.0 License)
 #pragma once

--- a/src/gpu/kmeans/kmeans_labels.cu
+++ b/src/gpu/kmeans/kmeans_labels.cu
@@ -1,5 +1,5 @@
 /*!
- * Modifications Copyright 2017 H2O.ai, Inc.
+ * Modifications Copyright 2017-2018 H2O.ai, Inc.
  */
 // original code from https://github.com/NVIDIA/kmeans (Apache V2.0 License)
 #include "kmeans_labels.h"

--- a/src/gpu/kmeans/kmeans_labels.h
+++ b/src/gpu/kmeans/kmeans_labels.h
@@ -1,5 +1,5 @@
 /*!
- * Modifications Copyright 2017 H2O.ai, Inc.
+ * Modifications Copyright 2017-2018 H2O.ai, Inc.
  */
 // original code from https://github.com/NVIDIA/kmeans (Apache V2.0 License)
 #pragma once

--- a/src/gpu/matrix/matrix_dense.cu
+++ b/src/gpu/matrix/matrix_dense.cu
@@ -1,5 +1,5 @@
 /*!
- * Modifications Copyright 2017 H2O.ai, Inc.
+ * Modifications Copyright 2017-2018 H2O.ai, Inc.
  */
 #include <stdio.h>
 #include <stdlib.h>

--- a/src/gpu/matrix/matrix_sparse.cu
+++ b/src/gpu/matrix/matrix_sparse.cu
@@ -1,5 +1,5 @@
 /*!
- * Modifications Copyright 2017 H2O.ai, Inc.
+ * Modifications Copyright 2017-2018 H2O.ai, Inc.
  */
 #include <cublas_v2.h>
 #include <cusparse.h>

--- a/src/gpu/matrix/utilities.cu
+++ b/src/gpu/matrix/utilities.cu
@@ -1,5 +1,5 @@
 /*!
- * Modifications Copyright 2017 H2O.ai, Inc.
+ * Modifications Copyright 2017-2018 H2O.ai, Inc.
  */
 #include <stdio.h>
 #include <assert.h>

--- a/src/gpu/matrix/utlities.cuh
+++ b/src/gpu/matrix/utlities.cuh
@@ -1,5 +1,5 @@
 /*!
- * Modifications Copyright 2017 H2O.ai, Inc.
+ * Modifications Copyright 2017-2018 H2O.ai, Inc.
  */
 #ifndef UTILITIES_CUH
 #define UTILITIES_CUH

--- a/src/gpu/p2pbwcheck.cu
+++ b/src/gpu/p2pbwcheck.cu
@@ -1,7 +1,7 @@
 /*
  * Copyright 1993-2015 NVIDIA Corporation.  All rights reserved.
  *
- * Modifications Copyright 2017 H2O.ai, Inc.
+ * Modifications Copyright 2017-2018 H2O.ai, Inc.
  */
 #if 1
 

--- a/src/gpu/projector/projector_cgls.cu
+++ b/src/gpu/projector/projector_cgls.cu
@@ -1,5 +1,5 @@
 /*!
- * Modifications Copyright 2017 H2O.ai, Inc.
+ * Modifications Copyright 2017-2018 H2O.ai, Inc.
  */
 #include <cublas_v2.h>
 

--- a/src/gpu/projector/projector_direct_dense.cu
+++ b/src/gpu/projector/projector_direct_dense.cu
@@ -1,5 +1,5 @@
 /*!
- * Modifications Copyright 2017 H2O.ai, Inc.
+ * Modifications Copyright 2017-2018 H2O.ai, Inc.
  */
 #include <cublas_v2.h>
 

--- a/src/gpu/utils.cu
+++ b/src/gpu/utils.cu
@@ -1,7 +1,7 @@
 /*************************************************************************
  * Copyright (c) 2015-2016, NVIDIA CORPORATION. All rights reserved.
  *
- * Modifications Copyright 2017 H2O.ai, Inc.
+ * Modifications Copyright 2017-2018 H2O.ai, Inc.
  ************************************************************************/
 #include <chrono>
 #include <cstdio>

--- a/src/gpu/warmstart.cu
+++ b/src/gpu/warmstart.cu
@@ -1,7 +1,7 @@
 /*************************************************************************
  * Copyright (c) 2015-2016, NVIDIA CORPORATION. All rights reserved.
  *
- * Modifications Copyright 2017 H2O.ai, Inc.
+ * Modifications Copyright 2017-2018 H2O.ai, Inc.
  ************************************************************************/
 #ifdef USE_NCCL
 

--- a/src/include/exception.h
+++ b/src/include/exception.h
@@ -7,7 +7,7 @@
 * this software and related documentation outside the terms of the EULA
 * is strictly prohibited.
 *
-* Modifications Copyright 2017 H2O.ai, Inc.
+* Modifications Copyright 2017-2018 H2O.ai, Inc.
 *
 */
 

--- a/src/include/helper_cuda.h
+++ b/src/include/helper_cuda.h
@@ -7,7 +7,7 @@
  * this software and related documentation outside the terms of the EULA
  * is strictly prohibited.
  *
- * Modifications Copyright 2017 H2O.ai, Inc.
+ * Modifications Copyright 2017-2018 H2O.ai, Inc.
  *
  */
 

--- a/src/include/helper_cuda_drvapi.h
+++ b/src/include/helper_cuda_drvapi.h
@@ -7,7 +7,7 @@
  * this software and related documentation outside the terms of the EULA
  * is strictly prohibited.
  *
- * Modifications Copyright 2017 H2O.ai, Inc.
+ * Modifications Copyright 2017-2018 H2O.ai, Inc.
  *
  */
 

--- a/src/include/helper_cuda_gl.h
+++ b/src/include/helper_cuda_gl.h
@@ -7,7 +7,7 @@
  * this software and related documentation outside the terms of the EULA
  * is strictly prohibited.
  *
- * Modifications Copyright 2017 H2O.ai, Inc.
+ * Modifications Copyright 2017-2018 H2O.ai, Inc.
  *
  */
 

--- a/src/include/helper_cusolver.h
+++ b/src/include/helper_cusolver.h
@@ -7,7 +7,7 @@
  * this software and related documentation outside the terms of the EULA
  * is strictly prohibited.
  *
- * Modifications Copyright 2017 H2O.ai, Inc.
+ * Modifications Copyright 2017-2018 H2O.ai, Inc.
  *
  */
 

--- a/src/include/helper_functions.h
+++ b/src/include/helper_functions.h
@@ -7,7 +7,7 @@
  * this software and related documentation outside the terms of the EULA
  * is strictly prohibited.
  *
- * Modifications Copyright 2017 H2O.ai, Inc.
+ * Modifications Copyright 2017-2018 H2O.ai, Inc.
  *
  */
 

--- a/src/include/helper_gl.h
+++ b/src/include/helper_gl.h
@@ -7,7 +7,7 @@
  * this software and related documentation outside the terms of the EULA
  * is strictly prohibited.
  *
- * Modifications Copyright 2017 H2O.ai, Inc.
+ * Modifications Copyright 2017-2018 H2O.ai, Inc.
  *
  */
 

--- a/src/include/helper_image.h
+++ b/src/include/helper_image.h
@@ -7,7 +7,7 @@
  * this software and related documentation outside the terms of the EULA
  * is strictly prohibited.
  *
- * Modifications Copyright 2017 H2O.ai, Inc.
+ * Modifications Copyright 2017-2018 H2O.ai, Inc.
  *
  */
 

--- a/src/include/helper_math.h
+++ b/src/include/helper_math.h
@@ -7,7 +7,7 @@
  * this software and related documentation outside the terms of the EULA
  * is strictly prohibited.
  *
- * Modifications Copyright 2017 H2O.ai, Inc.
+ * Modifications Copyright 2017-2018 H2O.ai, Inc.
  *
  */
 

--- a/src/include/helper_string.h
+++ b/src/include/helper_string.h
@@ -7,7 +7,7 @@
  * this software and related documentation outside the terms of the EULA
  * is strictly prohibited.
  *
- * Modifications Copyright 2017 H2O.ai, Inc.
+ * Modifications Copyright 2017-2018 H2O.ai, Inc.
  *
  */
 

--- a/src/include/helper_timer.h
+++ b/src/include/helper_timer.h
@@ -7,7 +7,7 @@
  * this software and related documentation outside the terms of the EULA
  * is strictly prohibited.
  *
- * Modifications Copyright 2017 H2O.ai, Inc.
+ * Modifications Copyright 2017-2018 H2O.ai, Inc.
  */
 
 // Helper Timing Functions

--- a/src/include/interface_defs.h
+++ b/src/include/interface_defs.h
@@ -1,5 +1,5 @@
 /*!
- * Modifications Copyright 2017 H2O.ai, Inc.
+ * Modifications Copyright 2017-2018 H2O.ai, Inc.
  */
 #ifndef INTERFACE_DEFS_H_
 #define INTERFACE_DEFS_H_

--- a/src/include/matrix/matrix.h
+++ b/src/include/matrix/matrix.h
@@ -1,5 +1,5 @@
 /*!
- * Modifications Copyright 2017 H2O.ai, Inc.
+ * Modifications Copyright 2017-2018 H2O.ai, Inc.
  */
 #ifndef MATRIX_MATRIX_H_
 #define MATRIX_MATRIX_H_

--- a/src/include/matrix/matrix_dense.h
+++ b/src/include/matrix/matrix_dense.h
@@ -1,5 +1,5 @@
 /*!
- * Modifications Copyright 2017 H2O.ai, Inc.
+ * Modifications Copyright 2017-2018 H2O.ai, Inc.
  */
 #ifndef MATRIX_MATRIX_DENSE_H_
 #define MATRIX_MATRIX_DENSE_H_

--- a/src/include/matrix/matrix_sparse.h
+++ b/src/include/matrix/matrix_sparse.h
@@ -1,5 +1,5 @@
 /*!
- * Modifications Copyright 2017 H2O.ai, Inc.
+ * Modifications Copyright 2017-2018 H2O.ai, Inc.
  */
 #ifndef MATRIX_MATRIX_SPARSE_H_
 #define MATRIX_MATRIX_SPARSE_H_

--- a/src/include/projector/projector.h
+++ b/src/include/projector/projector.h
@@ -1,5 +1,5 @@
 /*!
- * Modifications Copyright 2017 H2O.ai, Inc.
+ * Modifications Copyright 2017-2018 H2O.ai, Inc.
  */
 #ifndef PROJECTOR_PROJECTOR_H_
 #define PROJECTOR_PROJECTOR_H_ 

--- a/src/include/projector/projector_cgls.h
+++ b/src/include/projector/projector_cgls.h
@@ -1,5 +1,5 @@
 /*!
- * Modifications Copyright 2017 H2O.ai, Inc.
+ * Modifications Copyright 2017-2018 H2O.ai, Inc.
  */
 #ifndef PROJECTOR_PROJECTOR_CGLS_H_
 #define PROJECTOR_PROJECTOR_CGLS_H_ 

--- a/src/include/projector/projector_direct.h
+++ b/src/include/projector/projector_direct.h
@@ -1,5 +1,5 @@
 /*!
- * Modifications Copyright 2017 H2O.ai, Inc.
+ * Modifications Copyright 2017-2018 H2O.ai, Inc.
  */
 #ifndef PROJECTOR_PROJECTOR_DIRECT_H_
 #define PROJECTOR_PROJECTOR_DIRECT_H_ 

--- a/src/include/prox_lib.h
+++ b/src/include/prox_lib.h
@@ -1,5 +1,5 @@
 /*!
- * Modifications Copyright 2017 H2O.ai, Inc.
+ * Modifications Copyright 2017-2018 H2O.ai, Inc.
  */
 #ifndef PROX_LIB_H_
 #define PROX_LIB_H_

--- a/src/include/solver/glm.h
+++ b/src/include/solver/glm.h
@@ -1,5 +1,5 @@
 /*!
- * Modifications Copyright 2017 H2O.ai, Inc.
+ * Modifications Copyright 2017-2018 H2O.ai, Inc.
  */
 #ifdef __JETBRAINS_IDE__
 #define __host__

--- a/src/include/solver/kmeans.h
+++ b/src/include/solver/kmeans.h
@@ -1,5 +1,5 @@
 /*!
- * Copyright 2017 H2O.ai, Inc.
+ * Copyright 2017-2018 H2O.ai, Inc.
  * License   Apache License Version 2.0 (see LICENSE for details)
  */
 

--- a/src/include/timer.h
+++ b/src/include/timer.h
@@ -1,5 +1,5 @@
 /*!
- * Modifications Copyright 2017 H2O.ai, Inc.
+ * Modifications Copyright 2017-2018 H2O.ai, Inc.
  */
 #ifndef TIMER_H_
 #define TIMER_H_

--- a/src/include/util.h
+++ b/src/include/util.h
@@ -1,5 +1,5 @@
 /*!
- * Modifications Copyright 2017 H2O.ai, Inc.
+ * Modifications Copyright 2017-2018 H2O.ai, Inc.
  */
 #ifndef UTIL_H_
 #define UTIL_H_

--- a/src/interface_c/h2o4gpu_c.cpp
+++ b/src/interface_c/h2o4gpu_c.cpp
@@ -1,5 +1,5 @@
 /*!
- * Modifications Copyright 2017 H2O.ai, Inc.
+ * Modifications Copyright 2017-2018 H2O.ai, Inc.
  */
 #include "matrix/matrix_dense.h"
 #include "matrix/matrix_sparse.h"

--- a/src/interface_c/h2o4gpu_c.h
+++ b/src/interface_c/h2o4gpu_c.h
@@ -1,5 +1,5 @@
 /*!
- * Modifications Copyright 2017 H2O.ai, Inc.
+ * Modifications Copyright 2017-2018 H2O.ai, Inc.
  */
 #pragma once
 

--- a/src/interface_c/h2o4gpu_c_api.h
+++ b/src/interface_c/h2o4gpu_c_api.h
@@ -1,5 +1,5 @@
 /*!
- * Modifications Copyright 2017 H2O.ai, Inc.
+ * Modifications Copyright 2017-2018 H2O.ai, Inc.
  */
 #pragma once
 


### PR DESCRIPTION
* Python license headers have been updated here: https://github.com/h2oai/h2o4gpu/pull/614
* This PR updates license headers in all other parts of the h2o4gpu project