### PR TITLE
NVML path inside Centos docker

### DIFF
--- a/make/config.mk
+++ b/make/config.mk
@@ -41,5 +41,5 @@ R_VERSION = 3.1.0
 
 #
 # Find NVML library
-NVML_LIB := $(shell find /lib/ /usr/lib/|grep libnvidia-ml.so.1|head -1)
+NVML_LIB := $(shell find /lib/ /usr/|grep libnvidia-ml.so.1|head -1)
 $(warning Compiling with NVML_LIB=$(NVML_LIB))


### PR DESCRIPTION
Centos build failing because in Centos Docker the nvml lib resides under a bit different path `/usr/lib64/libnvidia-ml.so.1`.