### PR TITLE
Use same version of boost as Ubuntu 16.04

### DIFF
--- a/DEVEL.md
+++ b/DEVEL.md
@@ -41,6 +41,12 @@ If you are building the h2o4gpu R package, it is necessary to install the follow
 sudo apt-get -y install libcurl4-openssl-dev libssl-dev libxml2-dev
 ```
 
+If you want lightgbm support to work:
+
+```
+sudo apt-get -y install ibboost-dev libboost-system-dev libboost-filesystem-dev
+```
+
 If you are using `conda`, you probably need to do:
 ```
 conda install libgcc

--- a/Dockerfile-build
+++ b/Dockerfile-build
@@ -176,9 +176,9 @@ RUN \
     bash -c 'if [ `arch` != "ppc64le" ]; then \
     export CUDA_HOME=/usr/local/cuda/ && \
 	yum install -y opencl-headers icu libicu-devel bzip2 bzip2-devel zlib-devel python-devel && \
-    wget http://sourceforge.net/projects/boost/files/boost/1.56.0/boost_1_56_0.tar.bz2 && \
-    tar xjf boost_1_56_0.tar.bz2 && \
-    cd boost_1_56_0 && \
+    wget http://sourceforge.net/projects/boost/files/boost/1.58.0/boost_1_58_0.tar.bz2 && \
+    tar xjf boost_1_58_0.tar.bz2 && \
+    cd boost_1_58_0 && \
     export PYTHONPATH=/opt/h2oai/h2o4gpu/python/ && \
     ./bootstrap.sh --prefix=/opt/boost/ --with-python=python3 && \
     export CPPFLAGS="-I/opt/h2oai/h2o4gpu/python/include/python3.6m/" && \

--- a/README.md
+++ b/README.md
@@ -48,6 +48,13 @@ If you are building the h2o4gpu R package, it is necessary to install the follow
 sudo apt-get -y install libcurl4-openssl-dev libssl-dev libxml2-dev
 ```
 
+If you want lightgbm support to work:
+
+```
+sudo apt-get -y install ibboost-dev libboost-system-dev libboost-filesystem-dev
+```
+
+
 Download the Python wheel file (For Python 3.6 on linux_x86_64):
 
   * Stable:


### PR DESCRIPTION
Had difficulty getting static boost to build inside lightgbm
```
diff --git a/Dockerfile-build b/Dockerfile-build
index 9e688ea..de0d1a3 100644
--- a/Dockerfile-build
+++ b/Dockerfile-build
@@ -181,9 +181,11 @@ RUN \
     cd boost_1_58_0 && \
     export PYTHONPATH=/opt/h2oai/h2o4gpu/python/ && \
     ./bootstrap.sh --prefix=/opt/boost/ --with-python=python3 && \
-    export CPPFLAGS="-I/opt/h2oai/h2o4gpu/python/include/python3.6m/" && \
+    export CPPFLAGS="-I/opt/h2oai/h2o4gpu/python/include/python3.6m/ -fPIC" && \
+    export CFLAGS="-I/opt/h2oai/h2o4gpu/python/include/python3.6m/ -fPIC" && \
+    export CXXFLAGS="-I/opt/h2oai/h2o4gpu/python/include/python3.6m/ -fPIC" && \
     export C_INCLUDE_PATH="/opt/h2oai/h2o4gpu/python/include/python3.6m/" ; export CPLUS_INCLUDE_PATH="/opt/h2oai/h2o4gpu/python/include/python3.6m/" && \
-    ./b2 -a -d0 install --prefix=/opt/boost/ --with=all -j 20 && \
+    ./b2 -a -d0 --prefix=/opt/boost/ --with=all -j 20 link=static install && \
     cd /usr/include ; rm -rf boost ; ln -s /opt/boost/include/boost . && \
     cd /usr/lib64/ ; rm -rf libboost* ; cp -a /opt/boost/lib/* . && \
     cd / ; \
diff --git a/Makefile b/Makefile
index 9208dff..0178503 100644
--- a/Makefile
+++ b/Makefile
@@ -103,7 +103,7 @@ lightgbm:
        @echo "sudo apt-get install libboost-dev libboost-system-dev libboost-filesystem-dev cmake"
        if [ `arch` != "ppc64le" ]; then \
        rm -rf LightGBM ; result=`git clone --recursive https://github.com/Microsoft/LightGBM` && \
-       cd LightGBM && (rm -rf build || true) && mkdir -p build ; cd build && cmake .. -DUSE_GPU=1 -DCMAKE_C_COMPILER=/usr/bin/gcc -DCMAKE_CXX_COMPILER=/usr/bin/g++ -DOpenCL_LIBRARY=$(CUDA_HOME)/lib64/libOpenCL.so -DOpenCL_INCLUDE_DIR=$(CUDA_HOME)/include/ && \
+       cd LightGBM && (rm -rf build || true) && mkdir -p build ; cd build && cmake .. -DUSE_GPU=1 -DCMAKE_C_COMPILER=/usr/bin/gcc -DCMAKE_CXX_COMPILER=/usr/bin/g++ -DBoost_USE_STATIC_LIBS=1 -DOpenCL_LIBRARY=$(CUDA_HOME)/lib64/libOpenCL.so -DOpenCL_INCLUDE_DIR=$(CUDA_HOME)/include/ && \
        make OPENCL_HEADERS=$(CUDA_HOME)/targets/x86_64-linux/include LIBOPENCL=$(CUDA_HOME)/targets/x86_64-linux/lib -j && cd .. && \
        cd python-package &&  sed -i 's/self\.gpu \= 0/self.gpu = 1/g' setup.py && cd .. && \
        cd python-package &&  sed -i 's/self\.precompile \= 0/self.precompile = 1/g' setup.py && cd .. && \

```