### PR TITLE
Fix building.

### DIFF
--- a/src/common/utils.h
+++ b/src/common/utils.h
@@ -4,7 +4,7 @@
  */
 #pragma once
 #include <vector>
-#include "cblas.h"
+#include "cblas/cblas.h"
 
 template<typename T>
 void self_dot(std::vector<T> array_in, int n, int dim,

--- a/src/cpu/h2o4gpuglm.cpp
+++ b/src/cpu/h2o4gpuglm.cpp
@@ -6,6 +6,7 @@
 #include <algorithm>
 #include <limits>
 #include <deque>
+#include <numeric>
 
 #include <functional>
 #include <cstring>

--- a/src/cpu/h2o4gpukmeans.cpp
+++ b/src/cpu/h2o4gpukmeans.cpp
@@ -10,7 +10,7 @@
 #include <algorithm>
 #include <vector>
 //#include "mkl.h"
-#include "cblas.h"
+#include "cblas/cblas.h"
 #include <atomic>
 #include <csignal>
 

--- a/src/gpu/h2o4gpuglm.cu
+++ b/src/gpu/h2o4gpuglm.cu
@@ -10,6 +10,7 @@
 #include <thrust/transform.h>
 
 #include <algorithm>
+#include <numeric>
 #include <limits>
 #include <deque>
 


### PR DESCRIPTION
The build is performed by cmake. Add missing <numeric> header and use
cblas/cblas.h instead of cblas.h.

close #652
