### PR TITLE
R Documentation builds on all linux nodes

### DIFF
--- a/ci/Jenkinsfile-r-docs
+++ b/ci/Jenkinsfile-r-docs
@@ -19,7 +19,7 @@ pipeline {
     stages {
         stage("Generate Docs") {
             agent {
-                label "mr-0xc8"
+                label "linux && docker"
             }
             steps {
                 // Get source code
@@ -42,7 +42,7 @@ pipeline {
         }
         stage("Publish to S3") {
             agent {
-                label "mr-0xc8"
+                label "linux && docker"
             }
             steps {
                 dumpInfo()

--- a/ci/Jenkinsfile-r-docs
+++ b/ci/Jenkinsfile-r-docs
@@ -19,7 +19,7 @@ pipeline {
     stages {
         stage("Generate Docs") {
             agent {
-                label "linux && docker"
+                label "mr-0x6"
             }
             steps {
                 // Get source code
@@ -42,7 +42,7 @@ pipeline {
         }
         stage("Publish to S3") {
             agent {
-                label "linux && docker"
+                label "mr-0x6"
             }
             steps {
                 dumpInfo()


### PR DESCRIPTION
Changed the node label from `mr-0xc8` to `linux && docker`. Testing to see if the solution works.