### PR TITLE
Fix #175, #204

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -175,6 +175,7 @@ src/interface_py/h2o4gpu/libs/ch2o4gpu_cpuPYTHON_wrap.cxx
 src/interface_py/h2o4gpu/libs/ch2o4gpu_gpuPYTHON_wrap.cxx
 
 src/interface_py/h2o4gpu/BUILD_INFO.txt
+src/interface_py/build_info.txt
 
 # Temp requirement file generated for Conda
 src/interface_py/requirements_conda.txt

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -109,7 +109,7 @@ if(USE_CUDA)
                 SET(GPU_COMPUTE_VER 61 CACHE STRING
                         "Space separated list of compute versions to be built against")
                 SET(CMAKE_BUILD_TYPE Debug)
-                #add_compile_definitions(DEBUG)
+                add_compile_definitions(SYNC)
         else()
                 MESSAGE(STATUS "Building RELEASE compute capability version.")
                 SET(GPU_COMPUTE_VER 35;50;52;60;61 CACHE STRING

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -108,6 +108,8 @@ if(USE_CUDA)
                 MESSAGE(STATUS "Building DEVELOPER compute capability version.")
                 SET(GPU_COMPUTE_VER 61 CACHE STRING
                         "Space separated list of compute versions to be built against")
+                SET(CMAKE_BUILD_TYPE Debug)
+                #add_compile_definitions(DEBUG)
         else()
                 MESSAGE(STATUS "Building RELEASE compute capability version.")
                 SET(GPU_COMPUTE_VER 35;50;52;60;61 CACHE STRING

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -109,7 +109,7 @@ if(USE_CUDA)
                 SET(GPU_COMPUTE_VER 61 CACHE STRING
                         "Space separated list of compute versions to be built against")
                 SET(CMAKE_BUILD_TYPE Debug)
-                add_compile_definitions(SYNC)
+                # add_compile_definitions(SYNC)
         else()
                 MESSAGE(STATUS "Building RELEASE compute capability version.")
                 SET(GPU_COMPUTE_VER 35;50;52;60;61 CACHE STRING

--- a/Dockerfile-build
+++ b/Dockerfile-build
@@ -131,9 +131,9 @@ RUN \
 RUN bash -c 'if [ `arch` = "ppc64le" ]; then \
 	git clone https://github.com/apache/arrow.git && \
 	cd $HOME/arrow/cpp && \
-	git checkout tags/apache-arrow-0.8.0 && \
+	git checkout tags/apache-arrow-0.12.0 && \
     yum install -y boost-devel && \
-  	pip install numpy==1.14.5 cython && \
+  	pip install numpy==1.15.1 cython && \
 	cmake -DARROW_CXXFLAGS="-lutil" -DARROW_PYTHON=on && make -j && make install && \
 	cd $HOME/arrow/python && \
 	ARROW_HOME=/usr/local python setup.py install && \

--- a/Makefile
+++ b/Makefile
@@ -203,7 +203,9 @@ install: install_py
 # CLEANING TARGETS
 #########################################
 
-clean: clean_py3nvml clean_xgboost clean_lightgbm clean_deps clean_py  clean_cpp clean_nccl
+clean: clean_py3nvml clean_xgboost clean_lightgbm clean_deps clean_py  clean_cpp
+	@echo "nccl is not clearned as it takes too long to compile"
+	@echo "use 'make clean_nccl' to do it mannualy"
 	-rm -rf ./build
 	-rm -rf ./results/ ./tmp/
 

--- a/Makefile
+++ b/Makefile
@@ -204,7 +204,7 @@ install: install_py
 #########################################
 
 clean: clean_py3nvml clean_xgboost clean_lightgbm clean_deps clean_py  clean_cpp
-	@echo "nccl is not clearned as it takes too long to compile"
+	@echo "nccl is not cleaned as it takes too long to compile"
 	@echo "use 'make clean_nccl' to do it mannualy"
 	-rm -rf ./build
 	-rm -rf ./results/ ./tmp/

--- a/ci/Jenkinsfile.utils
+++ b/ci/Jenkinsfile.utils
@@ -117,7 +117,7 @@ void publishToS3(BuildInfo buildInfo, String extratag, String platform) {
 }
 
 void publishToPoboys(String platform) {
-    echo "Publishing to Poboy's internal conda repository - http://mr-dl19:6969/"
+    echo "Publishing to Poboy's internal conda repository - http://poboys.h2o.ai:6969/poboys/upload"
 
 
     def uploadURL = "http://poboys.h2o.ai:6969/poboys/upload"

--- a/src/cpu/matrix/matrix_dense.cpp
+++ b/src/cpu/matrix/matrix_dense.cpp
@@ -1032,7 +1032,7 @@ int makePtr_dense(int sharedA, int me, int wDev, size_t m, size_t n, size_t mVal
   template <typename T>
   int modelFree1(T *aptr){
     if(aptr!=NULL){
-      //      delete aptr; // for now, freed during ~
+        delete aptr;
     }
     return(0);
   }

--- a/src/cpu/matrix/matrix_dense.cpp
+++ b/src/cpu/matrix/matrix_dense.cpp
@@ -52,8 +52,11 @@ void MultDiag(const T *d, const T *e, size_t m, size_t n,
 
 }  // namespace
 
-  // TODO: Can have Equil (or whatever wants to modify _data) called by single core first when inporting data into _data.  Then rest of cores (in multi-threaded call to another MatrixDense(wDev,A) would not do equil and could pass only the pointer instead of creating new memory.
-  // TODO: For first core, could assign pointer if ok with input being modified.  Could have function call argument that allows user to say if ok to modify input data in order to save memory.
+  // TODO: Can have Equil (or whatever wants to modify _data) called by single core first when inporting 
+  // data into _data.  Then rest of cores (in multi-threaded call to another MatrixDense(wDev,A) would not 
+  // do equil and could pass only the pointer instead of creating new memory.
+  // TODO: For first core, could assign pointer if ok with input being modified.  Could have function call 
+  // argument that allows user to say if ok to modify input data in order to save memory.
   
 ////////////////////////////////////////////////////////////////////////////////
 /////////////////////// MatrixDense Implementation /////////////////////////////
@@ -465,7 +468,7 @@ MatrixDense<T>::MatrixDense(const MatrixDense<T>& A)
 template <typename T>
 MatrixDense<T>::~MatrixDense() {
 
-  if(0){
+  if(1){
     CpuData<T> *info = reinterpret_cast<CpuData<T>*>(this->_info);
     CpuData<T> *infoy = reinterpret_cast<CpuData<T>*>(this->_infoy);
     CpuData<T> *vinfo = reinterpret_cast<CpuData<T>*>(this->_vinfo);
@@ -482,7 +485,7 @@ MatrixDense<T>::~MatrixDense() {
     this->_weightinfo = 0;
   }
   
-  if(0){ // Note that this frees these pointers as soon as MatrixDense constructor goes out of scope, and might want more fine-grained control over GPU memory if inside (say) high-level python API
+  if(1){ // Note that this frees these pointers as soon as MatrixDense constructor goes out of scope, and might want more fine-grained control over GPU memory if inside (say) high-level python API
 
     if (this->_done_init && _data) {
       //      fprintf(stderr,"Freeing _data: %p\n",(void*)_data); fflush(stderr);
@@ -1039,11 +1042,11 @@ int makePtr_dense(int sharedA, int me, int wDev, size_t m, size_t n, size_t mVal
 
 }  // namespace h2o4gpu
 
-int modelfree1_float(float *aptr){
-  return h2o4gpu::modelFree1<float>(aptr);
+int modelfree1_float(float **aptr){
+  return h2o4gpu::modelFree1<float>(*aptr);
 }
-int modelfree1_double(double *aptr){
-  return h2o4gpu::modelFree1<double>(aptr);
+int modelfree1_double(double **aptr){
+  return h2o4gpu::modelFree1<double>(*aptr);
 }
 
   int make_ptr_double(int sharedA, int sourceme, int sourceDev, size_t mTrain, size_t n, size_t mValid, const char ord,

--- a/src/cpu/matrix/matrix_dense.cpp
+++ b/src/cpu/matrix/matrix_dense.cpp
@@ -1042,11 +1042,11 @@ int makePtr_dense(int sharedA, int me, int wDev, size_t m, size_t n, size_t mVal
 
 }  // namespace h2o4gpu
 
-int modelfree1_float(float **aptr){
-  return h2o4gpu::modelFree1<float>(*aptr);
+int modelfree1_float(float *aptr){
+  return h2o4gpu::modelFree1<float>(aptr);
 }
-int modelfree1_double(double **aptr){
-  return h2o4gpu::modelFree1<double>(*aptr);
+int modelfree1_double(double *aptr){
+  return h2o4gpu::modelFree1<double>(aptr);
 }
 
   int make_ptr_double(int sharedA, int sourceme, int sourceDev, size_t mTrain, size_t n, size_t mValid, const char ord,

--- a/src/gpu/data/matrix.cuh
+++ b/src/gpu/data/matrix.cuh
@@ -1,5 +1,5 @@
 #pragma once
-#include "../utils/utils.cuh"
+#include "utils.cuh"
 #include "../device/device_context.cuh"
 #include "cusolverDn.h"
 #include <../../../cub/cub/cub.cuh>

--- a/src/gpu/device/device_context.cuh
+++ b/src/gpu/device/device_context.cuh
@@ -1,6 +1,6 @@
 #pragma once
 #include "cublas_v2.h"
-#include "../utils/utils.cuh"
+#include "utils.cuh"
 #include <cusparse.h>
 #include <cusolverDn.h>
 

--- a/src/gpu/h2o4gpuglm.cu
+++ b/src/gpu/h2o4gpuglm.cu
@@ -951,15 +951,15 @@ H2O4GPU<T, M, P>::~H2O4GPU() {
 
 	if(1){
 	if (_z)
-		cudaFree(_z);
+		CUDACHECK(cudaFree(_z));
 	if (_zt)
-		cudaFree(_zt);
+        CUDACHECK(cudaFree(_zt));
 	if (_xp)
-		cudaFree(_xp);
+        CUDACHECK(cudaFree(_xp));
 	if (_trainPredsp)
-		cudaFree(_trainPredsp);
+        CUDACHECK(cudaFree(_trainPredsp));
 	if (_validPredsp)
-		cudaFree(_validPredsp);
+        CUDACHECK(cudaFree(_validPredsp));
 	CUDA_CHECK_ERR();
 	}
 	_z = _zt = _xp = _trainPredsp = _validPredsp = 0;

--- a/src/gpu/include/cuda_utils2.h
+++ b/src/gpu/include/cuda_utils2.h
@@ -4,6 +4,8 @@
 #ifndef _CUDA_UTILS2_H
 #define _CUDA_UTILS2_H
 
+#include "utils.cuh"
+
 #define CUDACHECK(cmd) do {                         \
     cudaError_t e = cmd;                              \
     if( e != cudaSuccess ) {                          \

--- a/src/gpu/include/cuda_utils2.h
+++ b/src/gpu/include/cuda_utils2.h
@@ -13,5 +13,32 @@
     }                                                 \
   } while(0)
 
+#define OK(cmd) {                                       \
+    cudaError_t e = cmd;                                \
+    if( e != cudaSuccess ) {                            \
+      printf("Cuda failure %s:%d '%s'\n",               \
+             __FILE__,__LINE__,cudaGetErrorString(e));  \
+      exit(EXIT_FAILURE);                               \
+    }                                                   \
+}
+
+#define SYNC_OK(cmd) {                                  \
+    safe_cuda(cmd);                                            \
+    safe_cuda(cudaDeviceSynchronize());                        \
+    safe_cuda(cudaGetLastError());                             \
+ } 
+
+#ifdef SYNC
+#define CUDACHECK(cmd) {                                \
+    SYNC_OK(cmd);                                       \
+ }
+#endif
+
+#ifndef SYNC
+#define CUDACHECK(cmd) {                                \
+    safe_cuda(cmd);                                            \
+}
+#endif
+
 
 #endif

--- a/src/gpu/include/utils.cuh
+++ b/src/gpu/include/utils.cuh
@@ -1,4 +1,7 @@
-#pragma once
+#ifndef SRC_GPU_INCLUDE_UTILS_CUH
+#define SRC_GPU_INCLUDE_UTILS_CUH
+
+// #pragma once
 #include "cublas_v2.h"
 #include <thrust/device_vector.h>
 #include <thrust/random.h>
@@ -11,6 +14,7 @@
 
 namespace h2o4gpu
 {
+
 #define h2o4gpu_error(x) error(x, __FILE__, __LINE__);
 
 	inline void error(const char* e, const char* file, int line)
@@ -33,7 +37,7 @@ namespace h2o4gpu
 	}
 
 
-#define safe_cuda(ans) throw_on_cuda_error((ans), __FILE__, __LINE__)
+#define safe_cuda(ans) h2o4gpu::throw_on_cuda_error((ans), __FILE__, __LINE__)
 
 	inline cudaError_t throw_on_cuda_error(cudaError_t code, const char* file, int line)
 	{
@@ -367,3 +371,5 @@ namespace h2o4gpu
 		                  });
 	}
 }
+
+#endif SRC_GPU_INCLUDE_UTILS_CUH

--- a/src/gpu/include/utils.cuh
+++ b/src/gpu/include/utils.cuh
@@ -1,7 +1,6 @@
 #ifndef SRC_GPU_INCLUDE_UTILS_CUH
 #define SRC_GPU_INCLUDE_UTILS_CUH
 
-// #pragma once
 #include "cublas_v2.h"
 #include <thrust/device_vector.h>
 #include <thrust/random.h>
@@ -14,7 +13,6 @@
 
 namespace h2o4gpu
 {
-
 #define h2o4gpu_error(x) error(x, __FILE__, __LINE__);
 
 	inline void error(const char* e, const char* file, int line)

--- a/src/gpu/matrix/matrix_dense.cu
+++ b/src/gpu/matrix/matrix_dense.cu
@@ -1820,7 +1820,6 @@ int MatrixDense<T>::Stats(int intercept, T *min, T *max, T *mean, T *var, T *sd,
     // Get Cublas handle
     GpuData<T> *info = reinterpret_cast<GpuData<T>*>(this->_info);
     cublasHandle_t hdl = info->handle;
-    fprintf(stderr,"_datay: %p\n",(void*)_datay); fflush(stderr);
     // Set up views for raw vectors.
     cml::vector<T> y_vec = cml::vector_view_array(_datay, this->_m); // b
     cml::vector<T> weight_vec;
@@ -2030,6 +2029,8 @@ int makePtr_dense(int sharedA, int me, int wDev, size_t m, size_t n, size_t mVal
 template <typename T>
 int modelFree1(T *aptr){
   if(aptr!=NULL){
+    // TODO: use T** instead everywhere to prevent a scenario when we keep an address of allocated memory 
+    // TODO: flush cpu cache as it can be invoked by background GC thread 
     CUDACHECK(cudaFree(aptr));
   }
   return(0);

--- a/src/gpu/matrix/matrix_dense.cu
+++ b/src/gpu/matrix/matrix_dense.cu
@@ -2042,11 +2042,9 @@ int modelFree1(T *aptr){
 }  // namespace h2o4gpu
 
 int modelfree1_double(double **aptr){
-    fprintf(stderr,"modelfree1_double: %p\n",(void**)aptr); fflush(stderr);
   return h2o4gpu::modelFree1<double>(*aptr);
 }
 int modelfree1_float(float **aptr){
-    fprintf(stderr,"modelfree1_float: %p\n",(void**)aptr); fflush(stderr);
   return h2o4gpu::modelFree1<float>(*aptr);
 }
 

--- a/src/gpu/matrix/matrix_dense.cu
+++ b/src/gpu/matrix/matrix_dense.cu
@@ -2041,11 +2041,11 @@ int modelFree1(T *aptr){
 
 }  // namespace h2o4gpu
 
-int modelfree1_double(double **aptr){
-  return h2o4gpu::modelFree1<double>(*aptr);
+int modelfree1_double(double *aptr){
+  return h2o4gpu::modelFree1<double>(aptr);
 }
-int modelfree1_float(float **aptr){
-  return h2o4gpu::modelFree1<float>(*aptr);
+int modelfree1_float(float *aptr){
+  return h2o4gpu::modelFree1<float>(aptr);
 }
 
 

--- a/src/gpu/pca/pca.cu
+++ b/src/gpu/pca/pca.cu
@@ -1,5 +1,5 @@
 #include "../../include/solver/pca.h"
-#include "../utils/utils.cuh"
+#include "utils.cuh"
 #include "../data/matrix.cuh"
 #include "../device/device_context.cuh"
 #include "../../include/solver/tsvd.h"

--- a/src/gpu/projector/projector_direct_dense.cu
+++ b/src/gpu/projector/projector_direct_dense.cu
@@ -76,7 +76,7 @@ template <typename T, typename M>
 ProjectorDirect<T, M>::~ProjectorDirect() {
 
 
-  if(0){ // FIXME: segfaults sometimes
+  if(1){ // FIXME: segfaults sometimes
 	  checkwDev(_wDev);
 	  CUDACHECK(cudaSetDevice(_wDev));
 

--- a/src/gpu/tsvd/tsvd.cu
+++ b/src/gpu/tsvd/tsvd.cu
@@ -1,6 +1,6 @@
 #include <cstdio>
 #include "cuda_runtime.h"
-#include "../utils/utils.cuh"
+#include "utils.cuh"
 #include "../device/device_context.cuh"
 #include "../../include/solver/tsvd.h"
 #include <ctime>

--- a/src/gpu/utils.cu
+++ b/src/gpu/utils.cu
@@ -15,6 +15,7 @@
 #include <cuda_runtime_api.h>
 #include "nvml.h"
 
+#include "include/utils.cuh"
 #include "include/cuda_utils2.h"
 
 int cudaresetdevice(int wDev, int nDev) {

--- a/src/interface_py/h2o4gpu/solvers/elastic_net.py
+++ b/src/interface_py/h2o4gpu/solvers/elastic_net.py
@@ -16,7 +16,7 @@ from h2o4gpu.linear_model import coordinate_descent as sk
 from ..solvers.utils import _setter
 
 from ..libs.lib_utils import get_lib
-from ..solvers.utils import prepare_and_upload_data, free_data, free_sols
+from ..solvers.utils import prepare_and_upload_data, free_sols
 
 class ElasticNetH2O(object):
     """H2O Elastic Net Solver for GPUs
@@ -484,6 +484,7 @@ class ElasticNetH2O(object):
     #source_dev here because generally want to take in any pointer,
     #not just from our test code
 
+    # pylint: disable=unused-argument
     def _fitorpredict_ptr(
             self,
             source_dev,
@@ -677,9 +678,6 @@ class ElasticNetH2O(object):
         self.count_full = count_full
         self.count_short = count_short
         self.count_more = count_more
-
-        # if free_input_data == 1:
-        #     free_data(self)
 
         # ####################################
         #PROCESS OUTPUT

--- a/src/interface_py/h2o4gpu/solvers/elastic_net.py
+++ b/src/interface_py/h2o4gpu/solvers/elastic_net.py
@@ -650,11 +650,11 @@ class ElasticNetH2O(object):
             self.glm_stop_early_error_fraction,
             self.max_iter, # 30
             self.verbose,
-            int(a) if a is not None else -1,
-            int(b) if b is not None else -1,
-            int(c) if c is not None else -1,
-            int(d) if d is not None else -1,
-            int(e) if e is not None else -1,
+            int(a.p) if a.p is not None else -1,
+            int(b.p) if b.p is not None else -1,
+            int(c.p) if c.p is not None else -1,
+            int(d.p) if d.p is not None else -1,
+            int(e.p) if e.p is not None else -1,
             self.store_full_path,
             self.x_vs_alpha_lambda,
             self.x_vs_alpha,
@@ -678,8 +678,8 @@ class ElasticNetH2O(object):
         self.count_short = count_short
         self.count_more = count_more
 
-        if free_input_data == 1:
-            free_data(self)
+        # if free_input_data == 1:
+        #     free_data(self)
 
         # ####################################
         #PROCESS OUTPUT

--- a/src/interface_py/h2o4gpu/solvers/utils.py
+++ b/src/interface_py/h2o4gpu/solvers/utils.py
@@ -10,6 +10,15 @@ import numpy as np
 # Data utils
 
 class WrappedPointer(object):
+    '''Wraps a native pointer and release underlying resources 
+    when notified by GC
+    
+    Arguments:
+        p {[type]} -- pointer
+        double_precision {bool} -- use double precision
+        lib{object} -- python wrapper over lib.so
+    '''
+
     def __init__(self, p, double_precision, lib):
         self.p = p
         self.double_precision = double_precision
@@ -409,28 +418,6 @@ def upload_data(self,
            WrappedPointer(e, self.double_precision == 1, self.lib)
 
 
-# Functions that free memory
-def free_data(self):
-    """Free Data
-    """
-    # NOTE : For now, these are automatically freed
-    # when done with fit-- ok, since not used again
-
-    if self.uploaded_data == 1:
-        self.uploaded_data = 0
-        if self.double_precision == 1:
-            self.lib.modelfree1_double(self.a)
-            self.lib.modelfree1_double(self.b)
-            self.lib.modelfree1_double(self.c)
-            self.lib.modelfree1_double(self.d)
-            self.lib.modelfree1_double(self.e)
-        else:
-            self.lib.modelfree1_float(self.a)
-            self.lib.modelfree1_float(self.b)
-            self.lib.modelfree1_float(self.c)
-            self.lib.modelfree1_float(self.d)
-            self.lib.modelfree1_float(self.e)
-
 def free_sols(self):
     if self.did_fit_ptr == 1:
         self.did_fit_ptr = 0
@@ -453,7 +440,12 @@ def free_preds(self):
             self.lib.modelfree2_float(self.valid_pred_vs_alpha)
 
 def finish(self):
-    free_data(self)
+    import warnings
+    warnings.warn("finish will be removed in a next version, please use 'del'", DeprecationWarning, stacklevel=2)
+    free_sols(self)
+    free_preds(self)
+
+def __del__(self):
     free_sols(self)
     free_preds(self)
 

--- a/src/interface_py/h2o4gpu/solvers/utils.py
+++ b/src/interface_py/h2o4gpu/solvers/utils.py
@@ -10,9 +10,9 @@ import numpy as np
 # Data utils
 
 class WrappedPointer(object):
-    '''Wraps a native pointer and release underlying resources 
+    '''Wraps a native pointer and release underlying resources
     when notified by GC
-    
+
     Arguments:
         p {[type]} -- pointer
         double_precision {bool} -- use double precision
@@ -441,7 +441,8 @@ def free_preds(self):
 
 def finish(self):
     import warnings
-    warnings.warn("finish will be removed in a next version, please use 'del'", DeprecationWarning, stacklevel=2)
+    warnings.warn("finish will be removed in a next version, please use 'del'",
+                  DeprecationWarning, stacklevel=2)
     free_sols(self)
     free_preds(self)
 

--- a/src/interface_py/h2o4gpu/solvers/utils.py
+++ b/src/interface_py/h2o4gpu/solvers/utils.py
@@ -9,6 +9,17 @@ import numpy as np
 
 # Data utils
 
+class WrappedPointer(object):
+    def __init__(self, p, double_precision, lib):
+        self.p = p
+        self.double_precision = double_precision
+        self.lib = lib
+    def __del__(self):
+        if self.double_precision:
+            self.lib.modelfree1_double(self.p)
+        else:
+            self.lib.modelfree1_float(self.p)
+
 def _get_order(data, fortran, order):
     """ Return the Unicode code point representing the
     order of this data set. """
@@ -271,12 +282,6 @@ def upload_data(self,
                 sample_weight=None,
                 source_dev=0):
     """Upload the data through the backend library"""
-    if self.uploaded_data == 1:
-        free_data(self)
-    self.uploaded_data = 1
-
-    #
-    # ################
 
     self.double_precision1, m_train, n1 = _data_info(train_x, self.verbose)
     self.m_train = m_train
@@ -392,12 +397,16 @@ def upload_data(self,
 
     assert status == 0, 'Failure uploading the data'
 
-    self.a = a
-    self.b = b
-    self.c = c
-    self.d = d
-    self.e = e
-    return a, b, c, d, e
+    # self.a = a
+    # self.b = b
+    # self.c = c
+    # self.d = d
+    # self.e = e
+    return WrappedPointer(a, self.double_precision == 1, self.lib),\
+           WrappedPointer(b, self.double_precision == 1, self.lib),\
+           WrappedPointer(c, self.double_precision == 1, self.lib),\
+           WrappedPointer(d, self.double_precision == 1, self.lib),\
+           WrappedPointer(e, self.double_precision == 1, self.lib)
 
 
 # Functions that free memory

--- a/src/interface_py/requirements_buildonly.txt
+++ b/src/interface_py/requirements_buildonly.txt
@@ -2,7 +2,7 @@
 apipkg==1.4
 attrs==17.4.0
 execnet==1.5.0
-pluggy==0.6.0
+pluggy==0.8.1
 py==1.5.2
 six==1.11.0
 yapf==0.17.0

--- a/src/interface_py/requirements_runtime.txt
+++ b/src/interface_py/requirements_runtime.txt
@@ -11,7 +11,7 @@ psutil==5.4.5
 # below for xgboost
 scikit-learn==0.19.1
 #sklearn==0.0
-pytest==3.5.1
+pytest==3.10.1
 pytest-forked==0.2
 pytest-xdist==1.22.2
 pytest-cov==2.5.1

--- a/src/swig/matrix/matrix_dense.i
+++ b/src/swig/matrix/matrix_dense.i
@@ -1,7 +1,7 @@
 /* File : matrix_dense.i */
 %{
-extern int modelfree1_float(float *aptr);
-extern int modelfree1_double(double *aptr);
+extern int modelfree1_float(float **aptr);
+extern int modelfree1_double(double **aptr);
 
 extern int modelfree2_float(float *aptr);
 extern int modelfree2_double(double *aptr);
@@ -10,8 +10,8 @@ extern int modelfree2_double(double *aptr);
 %apply float *INPUT {float *aptr}
 %apply double *INPUT {double *aptr}
 
-extern int modelfree1_float(float *aptr);
-extern int modelfree1_double(double *aptr);
+extern int modelfree1_float(float **aptr);
+extern int modelfree1_double(double **aptr);
 
 extern int modelfree2_float(float *aptr);
 extern int modelfree2_double(double *aptr);

--- a/src/swig/matrix/matrix_dense.i
+++ b/src/swig/matrix/matrix_dense.i
@@ -1,7 +1,7 @@
 /* File : matrix_dense.i */
 %{
-extern int modelfree1_float(float **aptr);
-extern int modelfree1_double(double **aptr);
+extern int modelfree1_float(float *aptr);
+extern int modelfree1_double(double *aptr);
 
 extern int modelfree2_float(float *aptr);
 extern int modelfree2_double(double *aptr);
@@ -10,8 +10,8 @@ extern int modelfree2_double(double *aptr);
 %apply float *INPUT {float *aptr}
 %apply double *INPUT {double *aptr}
 
-extern int modelfree1_float(float **aptr);
-extern int modelfree1_double(double **aptr);
+extern int modelfree1_float(float *aptr);
+extern int modelfree1_double(double *aptr);
 
 extern int modelfree2_float(float *aptr);
 extern int modelfree2_double(double *aptr);

--- a/tests/python/open_data/glm/test_elastic_net_ptr_driver.py
+++ b/tests/python/open_data/glm/test_elastic_net_ptr_driver.py
@@ -88,23 +88,9 @@ def ElasticNet(X, y, nGPUs=0, nlambda=100, nfolds=5, nalpha=5, validFraction=0.2
     print(trainW.dtype)
     a,b,c,d,e = prepare_and_upload_data(enet, trainX, trainY, validX, validY, trainW, source_dev = sourceDev)
 
-    print("=================================")
-    print(a, b, c, d, e)
-    print("=================================")
-
     # # swig a-e
     fit_predict(enet, fortran, mTrain, n, mvalid, validX, validY, validX2, validY2, a, b, c, d, e, sourceDev)
 
-    print("=================================")
-    print(a, b, c, d, e)
-    print("=================================")
-
-    # # integer a-e
-    # a_int = int(a) if a is not None else 0
-    # b_int = int(b) if b is not None else 0
-    # c_int = int(c) if c is not None else 0
-    # d_int = int(d) if d is not None else 0
-    # e_int = int(e) if e is not None else 0
     fit_predict(enet, fortran, mTrain, n, mvalid, validX, validY, validX2, validY2, a, b, c, d, e, sourceDev)
 
     return enet

--- a/tests/python/open_data/glm/test_elastic_net_ptr_driver.py
+++ b/tests/python/open_data/glm/test_elastic_net_ptr_driver.py
@@ -88,16 +88,24 @@ def ElasticNet(X, y, nGPUs=0, nlambda=100, nfolds=5, nalpha=5, validFraction=0.2
     print(trainW.dtype)
     a,b,c,d,e = prepare_and_upload_data(enet, trainX, trainY, validX, validY, trainW, source_dev = sourceDev)
 
-    # swig a-e
+    print("=================================")
+    print(a, b, c, d, e)
+    print("=================================")
+
+    # # swig a-e
     fit_predict(enet, fortran, mTrain, n, mvalid, validX, validY, validX2, validY2, a, b, c, d, e, sourceDev)
 
-    # integer a-e
-    a_int = int(a) if a is not None else 0
-    b_int = int(b) if b is not None else 0
-    c_int = int(c) if c is not None else 0
-    d_int = int(d) if d is not None else 0
-    e_int = int(e) if e is not None else 0
-    fit_predict(enet, fortran, mTrain, n, mvalid, validX, validY, validX2, validY2, a_int, b_int, c_int, d_int, e_int, sourceDev)
+    print("=================================")
+    print(a, b, c, d, e)
+    print("=================================")
+
+    # # integer a-e
+    # a_int = int(a) if a is not None else 0
+    # b_int = int(b) if b is not None else 0
+    # c_int = int(c) if c is not None else 0
+    # d_int = int(d) if d is not None else 0
+    # e_int = int(e) if e is not None else 0
+    fit_predict(enet, fortran, mTrain, n, mvalid, validX, validY, validX2, validY2, a, b, c, d, e, sourceDev)
 
     return enet
 

--- a/tests/python/open_data/system/test_freeing_memory.py
+++ b/tests/python/open_data/system/test_freeing_memory.py
@@ -17,7 +17,7 @@ def run(model, m, n, s):
     model.fit(X, y)
 
 def run_stress(model):
-    runs = 8
+    runs = 4
     n = 2048
     m_ratio = 2
     s_ratios = [0.2, 0.3, 0.4, 0.5, 0.6, 0.7, 0.8]

--- a/tests/python/open_data/system/test_freeing_memory.py
+++ b/tests/python/open_data/system/test_freeing_memory.py
@@ -1,0 +1,44 @@
+import numpy as np
+import h2o4gpu
+import random
+import time
+import h2o4gpu.solvers.utils
+import pytest
+
+def run(model, m, n, s):
+    X = np.random.uniform(-100, 100, size = (m, n))
+    coefs = np.random.randn(n)
+    const_coef = np.random.randn(1)
+
+    zero_coef_loc = random.sample(range(n), s)
+    coefs[zero_coef_loc] = 0
+
+    y = np.dot(X, coefs) + const_coef
+    model.fit(X, y)
+
+def run_stress(model):
+    runs = 8
+    n = 2048
+    m_ratio = 2
+    s_ratios = [0.2, 0.3, 0.4, 0.5, 0.6, 0.7, 0.8]
+
+    m = int(m_ratio * n)
+    for s_ratio in s_ratios:
+        s = int(s_ratio * n)
+        for i in range(runs):
+            run(model, m, n, s)
+
+def test_ridge(): run_stress(h2o4gpu.Ridge())
+def test_lasso(): run_stress(h2o4gpu.Lasso())
+# TODO: find out why it hangs
+@pytest.mark.skip(reason="It Hangs")
+def test_elasticnet(): run_stress(h2o4gpu.ElasticNet())
+def test_pca(): run_stress(h2o4gpu.PCA())
+def test_truncatedsvd(): run_stress(h2o4gpu.TruncatedSVD())
+
+if __name__ == "__main__":
+    test_ridge()
+    test_lasso()
+    #test_elasticnet()
+    test_pca()
+    test_truncatedsvd()


### PR DESCRIPTION
The goal of this PR is to fix memory leak with minimal changes. What was done:
- more fine-granted control of memory releasing in python api(it is released when `WrappedPointer` is deleted by GC)
- found and fixed a few missing deletion
- added a few tests that reproduce memory leak from #175 

Please let me know if I forget to fix/add something else(extra tests, documentation, etc)

We need more robust and clear logic when dealing with memory e.g. (not in this PR):
- memory ownership(current implementation vague a bit)
- use `T** data` instead of `T* data`  to detect that referenced pointer is freed
- cover with test cases scenarios when copying memory: cpu->gpu, gpu->gpu
- use `CUDACHECK` everywhere, it's difficult and time consuming sometimes to point an exact place in the code