### PR TITLE
Install gcc-5.3 and compile xgboost with it

### DIFF
--- a/Dockerfile-build
+++ b/Dockerfile-build
@@ -42,11 +42,11 @@ RUN yum install -y gcc gcc-c++ libgcc libstdc++ libgomp glibc
 RUN yum install -y libcurl-devel zlib-devel asciidoc xmlto wget make autoconf gettext gmp-devel mpfr-devel libmpc-devel
 
 #Install gcc from sources
-RUN wget https://0xdata-public.s3.amazonaws.com/gcc/gcc-5.5.0.tar.gz && \
-    tar zxf gcc-5.5.0.tar.gz && \
-    mkdir gcc-5.5.0-build && \
-    cd gcc-5.5.0-build && \
-    ../gcc-5.5.0/configure --program-suffix=-5.5 --enable-languages=c,c++ --disable-multilib && \
+RUN wget https://0xdata-public.s3.amazonaws.com/gcc/gcc-6.3.0.tar.gz && \
+    tar zxf gcc-6.3.0.tar.gz && \
+    mkdir gcc-6.3.0-build && \
+    cd gcc-6.3.0-build && \
+    ../gcc-6.3.0/configure --program-suffix=-6.3 --enable-languages=c,c++ --disable-multilib && \
     make -j$(nproc) && \
     make install
 
@@ -231,5 +231,5 @@ ENV GIT_AUTHOR_EMAIL="anonymous@h2o.ai"
 ENV GIT_COMMITTER_NAME="anonymous"
 ENV GIT_COMMITTER_EMAIL="anonymous@h2o.ai"
 ENV EMAIL="anonymous@h2o.ai"
-ENV XGB_CXX=g++-5.5
-ENV XGB_CC=gcc-5.5
+ENV XGB_CXX=g++-6.3
+ENV XGB_CC=gcc-6.3

--- a/Dockerfile-build
+++ b/Dockerfile-build
@@ -169,7 +169,7 @@ RUN bash -c 'if [ `arch` = "ppc64le" ]; then \
 #
 # Install Python requirements
 #
-RUN pip install numpy==1.16.4 scipy==1.2.2 setuptools==39.0.1
+RUN pip install numpy==1.16.4 scipy==1.2.1 setuptools==39.0.1
 
 RUN \
     git clone https://github.com/NVIDIA/nccl.git && \

--- a/Dockerfile-build
+++ b/Dockerfile-build
@@ -38,8 +38,17 @@ RUN yum install -y epel-release
 # Setup gcc etc.
 RUN yum install -y gcc gcc-c++ libgcc libstdc++ libgomp glibc
 
-# Git requirements
-RUN yum install -y libcurl-devel zlib-devel asciidoc xmlto wget make autoconf gettext
+# Git & gcc requirements
+RUN yum install -y libcurl-devel zlib-devel asciidoc xmlto wget make autoconf gettext gmp-devel mpfr-devel libmpc-devel
+
+#Install gcc from sources
+RUN wget https://0xdata-public.s3.amazonaws.com/gcc/gcc-6.5.0.tar.gz && \
+    tar zxf gcc-6.5.0.tar.gz && \
+    mkdir gcc-6.5.0-build && \
+    cd gcc-6.5.0-build && \
+    ../gcc-6.5.0/configure --program-suffix=-6.5 --enable-languages=c,c++ --disable-multilib && \
+    make -j$(nproc) && \
+    make install
 
 # Compile from source because yum's latest version is 1.8.3
 # --depth for submodule update which we use was added in 1.8.4
@@ -52,23 +61,25 @@ RUN \
     make all && \
     make install;
 
-# H2O4GPU requirements + util programs
+#H2O4GPU requirements
 RUN yum install -y \
     ncurses-devel \
-        bzip2 \
-        which \
-        axel \
-        cmake3 \
-        openssl-devel \
-        libpng-devel \
-        freetype-devel \
-        blas-devel \
-        epel-release \
-        zeromq-devel \
-        openblas-devel && \
-    wget https://repo.continuum.io/miniconda/Miniconda3-${MINICONDA_VERSION}-Linux-`arch`.sh && \
+    bzip2 \
+    which \
+    axel \
+    cmake3 \
+    openssl-devel \
+    libpng-devel \
+    freetype-devel \
+    blas-devel \
+    epel-release \
+    zeromq-devel \
+    openblas-devel
+
+# conda
+RUN wget https://repo.continuum.io/miniconda/Miniconda3-${MINICONDA_VERSION}-Linux-`arch`.sh && \
     bash Miniconda3-${MINICONDA_VERSION}-Linux-`arch`.sh -b -p /opt/h2oai/h2o4gpu/python && \
-    /opt/h2oai/h2o4gpu/python/bin/conda install -y conda-build six=1.11.0 && \
+    /opt/h2oai/h2o4gpu/python/bin/conda install -y python=3.6 pip=9.0.3 conda-build six=1.11.0 && \
     wget https://s3.amazonaws.com/artifacts.h2o.ai/releases/ai/h2o/dai-thirdparty-deps/1.0-master-2/`arch`-centos7/llvm.tar.bz2 && \
     tar xvf llvm.tar.bz2 && \
     cp -r llvm/* /opt/h2oai/h2o4gpu/ && \
@@ -110,9 +121,12 @@ RUN \
 #
 WORKDIR $HOME
 
+RUN python --version
+RUN pip --version
+
 # SWIG
 RUN \
-    wget https://sourceforge.net/projects/swig/files/swig/swig-${SWIG_VERSION}/swig-${SWIG_VERSION}.tar.gz && \
+    wget https://0xdata-public.s3.amazonaws.com/swig/swig-${SWIG_VERSION}.tar.gz && \
     tar -zxvf swig-${SWIG_VERSION}.tar.gz && \
     cd swig-${SWIG_VERSION} && \
     ./configure --prefix=/usr && \
@@ -161,16 +175,21 @@ RUN \
     git clone https://github.com/NVIDIA/nccl.git && \
     cd nccl && \
     git checkout tags/v2.4.7-1 && \
-    make -j src.build;
+    make CUDA8_GENCODE="-gencode=arch=compute_35,code=sm_35 -gencode=arch=compute_50,code=sm_50 -gencode=arch=compute_60,code=sm_60 -gencode=arch=compute_61,code=sm_61" -j src.build;
 
 
 COPY src/interface_py/requirements_buildonly.txt requirements_buildonly.txt
 COPY src/interface_py/requirements_runtime.txt requirements_runtime.txt
 COPY src/interface_py/requirements_runtime_demos.txt requirements_runtime_demos.txt
 
+RUN python --version
+RUN pip --version
+
 RUN pip install -r requirements_buildonly.txt
 RUN pip install -r requirements_runtime.txt
 RUN pip install -r requirements_runtime_demos.txt
+
+RUN python --version
 
 RUN mkdir -p /etc/OpenCL/vendors && \
     echo "libnvidia-opencl.so.1" > /etc/OpenCL/vendors/nvidia.icd
@@ -212,7 +231,7 @@ RUN bash -c 'if [ `arch` == "ppc64le" ]; then \
 
 
 ENV LD_LIBRARY_PATH=$LD_LIBRARY_PATH:/usr/lib64/nvidia
-ENV CUDA_TOOLKIT_ROOT_DIR=/usr/local/cuda-9.2
+ENV CUDA_TOOLKIT_ROOT_DIR=/usr/local/cuda
 
 WORKDIR $HOME
 

--- a/Dockerfile-build
+++ b/Dockerfile-build
@@ -42,11 +42,11 @@ RUN yum install -y gcc gcc-c++ libgcc libstdc++ libgomp glibc
 RUN yum install -y libcurl-devel zlib-devel asciidoc xmlto wget make autoconf gettext gmp-devel mpfr-devel libmpc-devel
 
 #Install gcc from sources
-RUN wget https://0xdata-public.s3.amazonaws.com/gcc/gcc-6.5.0.tar.gz && \
-    tar zxf gcc-6.5.0.tar.gz && \
-    mkdir gcc-6.5.0-build && \
-    cd gcc-6.5.0-build && \
-    ../gcc-6.5.0/configure --program-suffix=-6.5 --enable-languages=c,c++ --disable-multilib && \
+RUN wget https://0xdata-public.s3.amazonaws.com/gcc/gcc-5.5.0.tar.gz && \
+    tar zxf gcc-5.5.0.tar.gz && \
+    mkdir gcc-5.5.0-build && \
+    cd gcc-5.5.0-build && \
+    ../gcc-5.5.0/configure --program-suffix=-5.5 --enable-languages=c,c++ --disable-multilib && \
     make -j$(nproc) && \
     make install
 
@@ -231,5 +231,5 @@ ENV GIT_AUTHOR_EMAIL="anonymous@h2o.ai"
 ENV GIT_COMMITTER_NAME="anonymous"
 ENV GIT_COMMITTER_EMAIL="anonymous@h2o.ai"
 ENV EMAIL="anonymous@h2o.ai"
-ENV XGB_CXX=g++-6.5
-ENV XGB_CC=gcc-6.5
+ENV XGB_CXX=g++-5.5
+ENV XGB_CC=gcc-5.5

--- a/Dockerfile-build
+++ b/Dockerfile-build
@@ -76,10 +76,16 @@ RUN yum install -y \
     zeromq-devel \
     openblas-devel
 
+RUN \
+    git clone https://github.com/NVIDIA/nccl.git && \
+    cd nccl && \
+    git checkout tags/v2.4.7-1 && \
+    make CUDA8_GENCODE="-gencode=arch=compute_35,code=sm_35 -gencode=arch=compute_50,code=sm_50 -gencode=arch=compute_60,code=sm_60 -gencode=arch=compute_61,code=sm_61" -j src.build;
+
 # conda
 RUN wget https://repo.continuum.io/miniconda/Miniconda3-${MINICONDA_VERSION}-Linux-`arch`.sh && \
     bash Miniconda3-${MINICONDA_VERSION}-Linux-`arch`.sh -b -p /opt/h2oai/h2o4gpu/python && \
-    /opt/h2oai/h2o4gpu/python/bin/conda install -y python=3.6 conda-build six=1.11.0 && \
+    /opt/h2oai/h2o4gpu/python/bin/conda install -y python=3.6 PyYAML=3.13 conda-build six=1.11.0 && \
     wget https://s3.amazonaws.com/artifacts.h2o.ai/releases/ai/h2o/dai-thirdparty-deps/1.0-master-2/`arch`-centos7/llvm.tar.bz2 && \
     tar xvf llvm.tar.bz2 && \
     cp -r llvm/* /opt/h2oai/h2o4gpu/ && \
@@ -120,9 +126,6 @@ RUN \
 # Builds from source due to too old versions in yum
 #
 WORKDIR $HOME
-
-RUN python --version
-RUN pip --version
 
 # SWIG
 RUN \
@@ -171,25 +174,13 @@ RUN bash -c 'if [ `arch` = "ppc64le" ]; then \
 #
 RUN pip install numpy==1.16.4 scipy==1.2.1 setuptools==39.0.1
 
-RUN \
-    git clone https://github.com/NVIDIA/nccl.git && \
-    cd nccl && \
-    git checkout tags/v2.4.7-1 && \
-    make CUDA8_GENCODE="-gencode=arch=compute_35,code=sm_35 -gencode=arch=compute_50,code=sm_50 -gencode=arch=compute_60,code=sm_60 -gencode=arch=compute_61,code=sm_61" -j src.build;
-
-
 COPY src/interface_py/requirements_buildonly.txt requirements_buildonly.txt
 COPY src/interface_py/requirements_runtime.txt requirements_runtime.txt
 COPY src/interface_py/requirements_runtime_demos.txt requirements_runtime_demos.txt
 
-RUN python --version
-RUN pip --version
-
 RUN pip install -r requirements_buildonly.txt
 RUN pip install -r requirements_runtime.txt
 RUN pip install -r requirements_runtime_demos.txt
-
-RUN python --version
 
 RUN mkdir -p /etc/OpenCL/vendors && \
     echo "libnvidia-opencl.so.1" > /etc/OpenCL/vendors/nvidia.icd

--- a/Dockerfile-build
+++ b/Dockerfile-build
@@ -231,3 +231,5 @@ ENV GIT_AUTHOR_EMAIL="anonymous@h2o.ai"
 ENV GIT_COMMITTER_NAME="anonymous"
 ENV GIT_COMMITTER_EMAIL="anonymous@h2o.ai"
 ENV EMAIL="anonymous@h2o.ai"
+ENV XGB_CXX=g++-6.5
+ENV XGB_CC=gcc-6.5

--- a/Dockerfile-build
+++ b/Dockerfile-build
@@ -42,11 +42,11 @@ RUN yum install -y gcc gcc-c++ libgcc libstdc++ libgomp glibc
 RUN yum install -y libcurl-devel zlib-devel asciidoc xmlto wget make autoconf gettext gmp-devel mpfr-devel libmpc-devel
 
 #Install gcc from sources
-RUN wget https://0xdata-public.s3.amazonaws.com/gcc/gcc-6.3.0.tar.gz && \
-    tar zxf gcc-6.3.0.tar.gz && \
-    mkdir gcc-6.3.0-build && \
-    cd gcc-6.3.0-build && \
-    ../gcc-6.3.0/configure --program-suffix=-6.3 --enable-languages=c,c++ --disable-multilib && \
+RUN wget https://0xdata-public.s3.amazonaws.com/gcc/gcc-5.3.0.tar.gz && \
+    tar zxf gcc-5.3.0.tar.gz && \
+    mkdir gcc-5.3.0-build && \
+    cd gcc-5.3.0-build && \
+    ../gcc-5.3.0/configure --program-suffix=-5.3 --enable-languages=c,c++ --disable-multilib && \
     make -j$(nproc) && \
     make install
 
@@ -231,5 +231,5 @@ ENV GIT_AUTHOR_EMAIL="anonymous@h2o.ai"
 ENV GIT_COMMITTER_NAME="anonymous"
 ENV GIT_COMMITTER_EMAIL="anonymous@h2o.ai"
 ENV EMAIL="anonymous@h2o.ai"
-ENV XGB_CXX=g++-6.3
-ENV XGB_CC=gcc-6.3
+ENV XGB_CXX=g++-5.3
+ENV XGB_CC=gcc-5.3

--- a/Dockerfile-build
+++ b/Dockerfile-build
@@ -79,7 +79,7 @@ RUN yum install -y \
 # conda
 RUN wget https://repo.continuum.io/miniconda/Miniconda3-${MINICONDA_VERSION}-Linux-`arch`.sh && \
     bash Miniconda3-${MINICONDA_VERSION}-Linux-`arch`.sh -b -p /opt/h2oai/h2o4gpu/python && \
-    /opt/h2oai/h2o4gpu/python/bin/conda install -y python=3.6 pip=9.0.3 conda-build six=1.11.0 && \
+    /opt/h2oai/h2o4gpu/python/bin/conda install -y python=3.6 conda-build six=1.11.0 && \
     wget https://s3.amazonaws.com/artifacts.h2o.ai/releases/ai/h2o/dai-thirdparty-deps/1.0-master-2/`arch`-centos7/llvm.tar.bz2 && \
     tar xvf llvm.tar.bz2 && \
     cp -r llvm/* /opt/h2oai/h2o4gpu/ && \

--- a/Makefile
+++ b/Makefile
@@ -99,7 +99,7 @@ py: apply-sklearn_simple build/VERSION.txt
 .PHONY: xgboost
 xgboost:
 	@echo "----- Building XGboost target $(XGBOOST_TARGET) -----"
-	cd xgboost ; make -f Makefile2 PYTHON=$(PYTHON) CXX=$(XGB_CXX) $(XGBOOST_TARGET)
+	cd xgboost ; make -f Makefile2 PYTHON=$(PYTHON) CXX=$(XGB_CXX) CC=$(XGB_CC) $(XGBOOST_TARGET)
 
 fullinstall-xgboost: nccl xgboost install_xgboost
 

--- a/Makefile
+++ b/Makefile
@@ -99,7 +99,7 @@ py: apply-sklearn_simple build/VERSION.txt
 .PHONY: xgboost
 xgboost:
 	@echo "----- Building XGboost target $(XGBOOST_TARGET) -----"
-	cd xgboost ; make -f Makefile2 PYTHON=$(PYTHON) $(XGBOOST_TARGET)
+	cd xgboost ; make -f Makefile2 PYTHON=$(PYTHON) CXX=$(XGB_CXX) $(XGBOOST_TARGET)
 
 fullinstall-xgboost: nccl xgboost install_xgboost
 

--- a/make/config.mk
+++ b/make/config.mk
@@ -24,6 +24,10 @@ DEPS_DIR = deps
 # NCCL support in XGBoost.
 USENCCL=1
 
+# xgboost cxx
+XGB_CXX ?= c++
+XGB_CC ?= cc
+
 # By default build both CPU and GPU variant
 USECUDA=1
 

--- a/scripts/make-docker-devel.sh
+++ b/scripts/make-docker-devel.sh
@@ -21,7 +21,7 @@ $DOCKER_CLI exec ${CONTAINER_NAME} bash -c 'mkdir -p repo ; cp -a /dot/. ./repo'
 
 # workaround to not compile nccl every time
 echo "init submodules ${H2O4GPU_BUILD} and ${H2O4GPU_SUFFIX}"
-$DOCKER_CLI exec ${CONTAINER_NAME} bash -c "cd repo ; make ${makeopts} deps_fetch H2O4GPU_BUILD=${H2O4GPU_BUILD} H2O4GPU_SUFFIX=${H2O4GPU_SUFFIX}"
+$DOCKER_CLI exec ${CONTAINER_NAME} bash -c "cd repo && make ${makeopts} deps_fetch H2O4GPU_BUILD=${H2O4GPU_BUILD} H2O4GPU_SUFFIX=${H2O4GPU_SUFFIX}"
 
 echo "Docker devel - Copying nccl build artifacts"
 $DOCKER_CLI exec ${CONTAINER_NAME} bash -c 'if [  $(git -C /root/nccl rev-parse HEAD) != $(git -C /root/repo rev-parse :nccl) ]; then echo "NCCL version mismatch in nccl submodule and docker file" && exit 1;  fi;'   
@@ -44,9 +44,9 @@ mkdir -p build ; $DOCKER_CLI cp ${CONTAINER_NAME}:/root/repo/build/VERSION.txt b
 if [ `arch` != "ppc64le" ]; then
     echo "Docker devel - Creating conda package"
     $DOCKER_CLI exec ${CONTAINER_NAME} bash -c "mkdir -p repo/condapkgs"
-    $DOCKER_CLI exec ${CONTAINER_NAME} bash -c "cd repo/src/interface_py; cat requirements_*.txt | grep -v '#' | sort | uniq > requirements_conda.txt"
-    $DOCKER_CLI exec ${CONTAINER_NAME} bash -c "pushd repo/conda-recipe; sed -i 's/condapkgname/${CONDA_PKG_NAME}/g' meta.yaml; popd"
-    $DOCKER_CLI exec ${CONTAINER_NAME} bash -c "pushd repo/conda-recipe; conda build --output-folder ../condapkgs  -c h2oai -c conda-forge .; popd"
+    $DOCKER_CLI exec ${CONTAINER_NAME} bash -c "cd repo/src/interface_py && cat requirements_*.txt | grep -v '#' | sort | uniq > requirements_conda.txt"
+    $DOCKER_CLI exec ${CONTAINER_NAME} bash -c "pushd repo/conda-recipe && sed -i 's/condapkgname/${CONDA_PKG_NAME}/g' meta.yaml && popd"
+    $DOCKER_CLI exec ${CONTAINER_NAME} bash -c "pushd repo/conda-recipe && conda build --output-folder ../condapkgs  -c h2oai -c conda-forge .&& popd"
 
     echo "Docker devel - Copying conda package"
     rm -rf condapkgs

--- a/scripts/make-docker-devel.sh
+++ b/scripts/make-docker-devel.sh
@@ -24,8 +24,8 @@ echo "init submodules ${H2O4GPU_BUILD} and ${H2O4GPU_SUFFIX}"
 $DOCKER_CLI exec ${CONTAINER_NAME} bash -c "cd repo && make ${makeopts} deps_fetch H2O4GPU_BUILD=${H2O4GPU_BUILD} H2O4GPU_SUFFIX=${H2O4GPU_SUFFIX}"
 
 echo "Docker devel - Copying nccl build artifacts"
-$DOCKER_CLI exec ${CONTAINER_NAME} bash -c 'if [  $(git -C /root/nccl rev-parse HEAD) != $(git -C /root/repo rev-parse :nccl) ]; then echo "NCCL version mismatch in nccl submodule and docker file" && exit 1;  fi;'   
-$DOCKER_CLI exec ${CONTAINER_NAME} bash -c 'cp -r /root/nccl/build /root/repo/nccl'
+$DOCKER_CLI exec ${CONTAINER_NAME} bash -c 'if [  $(git -C /nccl rev-parse HEAD) != $(git -C /root/repo rev-parse :nccl) ]; then echo "NCCL version mismatch in nccl submodule and docker file" && exit 1;  fi;'   
+$DOCKER_CLI exec ${CONTAINER_NAME} bash -c 'cp -r /nccl/build /root/repo/nccl'
 
 echo "make buildinstall with ${H2O4GPU_BUILD} and ${H2O4GPU_SUFFIX}"
 $DOCKER_CLI exec ${CONTAINER_NAME} bash -c "cd repo && make ${makeopts} buildinstall H2O4GPU_BUILD=${H2O4GPU_BUILD} H2O4GPU_SUFFIX=${H2O4GPU_SUFFIX} && make py_docs"

--- a/src/interface_py/requirements_buildonly.txt
+++ b/src/interface_py/requirements_buildonly.txt
@@ -29,7 +29,7 @@ feather-format==0.4.0
 psutil==5.6.3
 PyYAML==5.1.1
 # below for sync with aws s3
-colorama==0.3.8
+colorama==0.4.1
 awscli==1.16.192
 # for pycharm
 matplotlib==2.0.2

--- a/src/interface_py/requirements_buildonly.txt
+++ b/src/interface_py/requirements_buildonly.txt
@@ -21,14 +21,16 @@ pandas==0.24.2
 numpy==1.16.4
 # for some utilities
 nbconvert==5.3.1
-nbformat==4.3.0
+nbformat==4.4.0
 notebook==5.7.8
 # below for some tests
 numba==0.38.0
 feather-format==0.4.0
 psutil==5.6.3
+#PyYAML==3.13
 # below for sync with aws s3
-awscli==1.15.6
+colorama==0.3.8
+awscli==1.16.192
 # for pycharm
 matplotlib==2.0.2
 llvmlite==0.23.0

--- a/src/interface_py/requirements_buildonly.txt
+++ b/src/interface_py/requirements_buildonly.txt
@@ -27,9 +27,9 @@ notebook==5.7.8
 numba==0.38.0
 feather-format==0.4.0
 psutil==5.6.3
-PyYAML==5.1.1
+PyYAML==3.13
+colorama==0.3.8
 # below for sync with aws s3
-colorama==0.4.1
 awscli==1.16.192
 # for pycharm
 matplotlib==2.0.2

--- a/src/interface_py/requirements_buildonly.txt
+++ b/src/interface_py/requirements_buildonly.txt
@@ -28,7 +28,7 @@ numba==0.38.0
 feather-format==0.4.0
 psutil==5.6.3
 PyYAML==3.13
-colorama==0.3.8
+colorama==0.3.9
 # below for sync with aws s3
 awscli==1.16.192
 # for pycharm

--- a/src/interface_py/requirements_buildonly.txt
+++ b/src/interface_py/requirements_buildonly.txt
@@ -27,7 +27,7 @@ notebook==5.7.8
 numba==0.38.0
 feather-format==0.4.0
 psutil==5.6.3
-#PyYAML==3.13
+PyYAML==5.1.1
 # below for sync with aws s3
 colorama==0.3.8
 awscli==1.16.192

--- a/src/interface_py/requirements_runtime.txt
+++ b/src/interface_py/requirements_runtime.txt
@@ -3,7 +3,7 @@ pandas==0.24.2
 numpy==1.16.4
 python-dateutil==2.7.2
 pytz==2018.4
-scipy==1.2.2
+scipy==1.2.1
 tabulate==0.8.2
 future==0.16.0
 # below for some testing utils that can be run at runtime


### PR DESCRIPTION
This is a preliminary PR to build xgboost with gcc-6.
It includes:
* build gcc-6 from sources, but it's not used
* fix python version(back to 3.6), conda start to use python 3.7 by default
* NCCL use arc >=35
* a few dependencies
* rollback scipy to 1.2.1 as there's no 1.2.2 conda release yet(or it's going to be skipped)
* MAKE master green again 