### PR TITLE
Add F0.5 and F2 to metrics computed by confusion_matrices().

### DIFF
--- a/src/interface_py/h2o4gpu/util/metrics.py
+++ b/src/interface_py/h2o4gpu/util/metrics.py
@@ -414,7 +414,7 @@ def confusion_matrices(actual, predicted, sample_weight=None):
     :returns: pandas DataFrame
              Confusion matrices for each unique predicted value as threshold
     """
-    cm_stats_cols = ['p', 'tp', 'tn', 'fp', 'fn', 'fpr', 'tpr', 'mcc', 'f1']
+    cm_stats_cols = ['p', 'tp', 'tn', 'fp', 'fn', 'fpr', 'tpr', 'mcc', 'f1', 'f05', 'f2']
 
     res = np.zeros((actual.shape[0], len(cm_stats_cols)))
     from ..libs.lib_utils import CPUlib


### PR DESCRIPTION
This will allow us to use F0.5 and F2 as threshold scorers in DAI 1.9.0