### PR TITLE
Add rmarkdown to list of suggests in DESCRIPTION file

### DIFF
--- a/src/interface_r/DESCRIPTION
+++ b/src/interface_r/DESCRIPTION
@@ -28,5 +28,6 @@ Roxygen: list(markdown = TRUE)
 RoxygenNote: 6.0.1
 Suggests:
     testthat,
-    knitr
+    knitr,
+    rmarkdown
 VignetteBuilder: knitr


### PR DESCRIPTION
Below is the message from CRAN. *Please fix before 2021-05-14 to safely retain your package on CRAN.*

Could the current maintainers of this repo make a new release and submit to CRAN? Otherwise it will be removed by 05-14. 

With the current CRAN version of knitr, building your package vignettes
now fails with something like
 
The 'markdown' package should be declared as a dependency of the
  'unrepx' package (e.g., in the 'Suggests' field of DESCRIPTION),
  because the latter contains vignette(s) built with the 'markdown'
  package. Please see https://github.com/yihui/knitr/issues/1864 for
  more information.

(for vignette engine knitr::knitr et al) or

  The 'rmarkdown' package should be declared as a dependency of the
  'validate' package (e.g., in the 'Suggests' field of DESCRIPTION),
  because the latter contains vignette(s) built with the 'rmarkdown'
  package. Please see https://github.com/yihui/knitr/issues/1864 for
  more information.

(for vignette engine knitr::rmarkdown).

See

  https://github.com/yihui/knitr/issues/1864

for more information.

Can you please add the missing dependencies and submit a new version of
your package to CRAN as quickly as possible?

Please fix before 2021-05-14 to safely retain your package on CRAN.